### PR TITLE
repositoryテストの実装

### DIFF
--- a/src/main/resources/db/migration/V004__Create maintenance_tasks table.sql
+++ b/src/main/resources/db/migration/V004__Create maintenance_tasks table.sql
@@ -2,7 +2,7 @@ CREATE TABLE maintenance_tasks (
     id INT AUTO_INCREMENT PRIMARY KEY COMMENT 'メンテナンスタスクID（主キー）',
     category_id INT NOT NULL COMMENT 'カテゴリID（外部キー）',
     name VARCHAR(100) NOT NULL COMMENT 'タスク名',
-    ai_guidance TEXT NOT NULL COMMENT 'AIが生成したメンテナンス手順・必要物品情報',
+    description TEXT NOT NULL COMMENT '生成したメンテナンス手順・必要物品情報',
     is_deleted BOOLEAN NOT NULL DEFAULT FALSE COMMENT '論理削除フラグ',
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時',
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',

--- a/src/test/java/com/rikuto/revox/repository/MaintenanceTaskRepositoryTest.java
+++ b/src/test/java/com/rikuto/revox/repository/MaintenanceTaskRepositoryTest.java
@@ -52,14 +52,14 @@ class MaintenanceTaskRepositoryTest {
 		MaintenanceTask testSecondTask = MaintenanceTask.builder()
 				.category(savedTestCategory)
 				.name("テストタスク")
-				.description("testtest")
+				.description("testTest")
 				.createdAt(now)
 				.updatedAt(now)
 				.build();
 
 		// 意図しないデータが取得されないことを確認するため、別カテゴリーの整備タスクも作成
 		Category anotherCategory = Category.builder()
-				.name("testCategory")
+				.name("categoryTest")
 				.displayOrder(888888888)
 				.createdAt(now)
 				.updatedAt(now)
@@ -69,7 +69,7 @@ class MaintenanceTaskRepositoryTest {
 		MaintenanceTask anotherCategoryByTask = MaintenanceTask.builder()
 				.category(savedAnotherCategory)
 				.name("テストタスク")
-				.description("testtest")
+				.description("testTest")
 				.createdAt(now)
 				.updatedAt(now)
 				.build();

--- a/src/test/java/com/rikuto/revox/repository/UserRepositoryTest.java
+++ b/src/test/java/com/rikuto/revox/repository/UserRepositoryTest.java
@@ -199,35 +199,4 @@ class UserRepositoryTest{
 		assertThatThrownBy(() -> userRepository.save(user4))
 				.isInstanceOf(DataIntegrityViolationException.class);
 	}
-
-	@Test
-	void 登録されたユーザーのニックネームが50文字を超えた場合DataIntegrityViolationExceptionを投げること() {
-		// Given
-		String longNickname = "a".repeat(51);
-		User invalidUser = User.builder()
-				.nickname(longNickname)
-				.email("too.long.nickname@example.com")
-				.createdAt(now)
-				.updatedAt(now)
-				.build();
-
-		// When & Then
-		assertThatThrownBy(() -> userRepository.save(invalidUser))
-				.isInstanceOf(DataIntegrityViolationException.class);
-	}
-
-	@Test
-	void ニックネームがnullの場合DataIntegrityViolationExceptionを投げること() {
-		// Given
-		User invalidUser = User.builder()
-				.nickname(null)
-				.email("test@example.com")
-				.createdAt(now)
-				.updatedAt(now)
-				.build();
-
-		// When & Then
-		assertThatThrownBy(() -> userRepository.save(invalidUser))
-				.isInstanceOf(DataIntegrityViolationException.class);
-	}
 }


### PR DESCRIPTION
## 初めに
今回作業中に別項目で修正対応が必要な内容があり作業中のブランチより新規ブランチを切って対応を行った。
修正後mergeを行ったが本RRの内容を含んでいたためself　mergeしてしまっていたため差分が少なくなっている。
Git運用が未熟のため今後差分管理を徹底して行っていく。

## 概要
本PRはrepositoryのテストを実装
CategoryRepositoryとServiceRecordRepositoryに関しては現状JPAの提供する機能でのCRUD操作のみで対応可能と判断しておりテストの作成は行っていません。
作成したテストは
- UserRepositoryTest
- BikeRepositoryTest
- MaintenanceTaskRepositoryTest
となります。
正常系・異常系を含む全18項目となります。

## テスト結果
<img width="1322" height="455" alt="image" src="https://github.com/user-attachments/assets/9387d429-d52f-4b4e-813c-e09c80a70b9d" />
