### PR TITLE
Bikeに関するCRUDの実装と例外処理の実装

### DIFF
--- a/src/main/java/com/rikuto/revox/controller/BikeController.java
+++ b/src/main/java/com/rikuto/revox/controller/BikeController.java
@@ -1,0 +1,69 @@
+package com.rikuto.revox.controller;
+
+import com.rikuto.revox.dto.bike.BikeCreateRequest;
+import com.rikuto.revox.dto.bike.BikeResponse;
+import com.rikuto.revox.service.BikeService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/bikes")
+public class BikeController {
+
+	private final BikeService bikeService;
+
+	public BikeController(BikeService bikeService) {
+		this.bikeService = bikeService;
+	}
+
+	/**
+	 * 指定されたユーザーIDに紐づくバイク情報を取得します。
+	 * GET /api/bikes/user/{userId}
+	 * @param userId バイクを検索するユーザーのID
+	 * @return 検索されたバイク情報（BikeResponse）とHTTPステータス200 OK
+	 */
+	@GetMapping("/user/{userId}")
+	public ResponseEntity<BikeResponse> getBikeByUserId(@PathVariable Integer userId) {
+		BikeResponse bikeResponse = bikeService.findBikeByUserId(userId);
+		return ResponseEntity.ok(bikeResponse);
+	}
+
+	/**
+	 * 新しいバイク情報を登録します。
+	 * POST /api/bikes
+	 * @param request 登録するバイク情報を含むリクエストDTO
+	 * @return 登録されたバイク情報（BikeResponse）とHTTPステータス201 Created
+	 */
+	@PostMapping
+	public ResponseEntity<BikeResponse> registerBike(@RequestBody @Valid BikeCreateRequest request) {
+		BikeResponse registeredBike = bikeService.registerBike(request);
+		return new ResponseEntity<>(registeredBike, HttpStatus.CREATED);
+	}
+
+	/**
+	 * 既存のバイク情報を更新します。
+	 * PUT /api/bikes/{bikeId}
+	 * @param bikeId 更新するバイクのID
+	 * @param request 更新されたバイク情報を含むリクエストDTO
+	 * @return 更新されたバイク情報（BikeResponse）とHTTPステータス200 OK
+	 */
+	@PutMapping("/{bikeId}")
+	public ResponseEntity<BikeResponse> updateBike(@PathVariable Integer bikeId, @RequestBody @Valid BikeCreateRequest request) {
+		BikeResponse bikeResponse = bikeService.updateBike(bikeId, request);
+		return ResponseEntity.ok(bikeResponse);
+	}
+
+	/**
+	 * バイク情報を論理削除します。
+	 * DELETE /api/bikes/{bikeId}
+	 * @param bikeId 論理削除するバイクのID
+	 * @return HTTPステータス204 No Content
+	 */
+	@DeleteMapping("/{bikeId}")
+	public ResponseEntity<Void> softDeleteBike(@PathVariable Integer bikeId) {
+		bikeService.softDeleteBike(bikeId);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/com/rikuto/revox/converter/BikeConverter.java
+++ b/src/main/java/com/rikuto/revox/converter/BikeConverter.java
@@ -1,0 +1,92 @@
+package com.rikuto.revox.converter;
+
+import com.rikuto.revox.dto.bike.BikeCreateRequest;
+import com.rikuto.revox.dto.bike.BikeResponse;
+import com.rikuto.revox.entity.Bike;
+import com.rikuto.revox.entity.User;
+import com.rikuto.revox.exception.ResourceNotFoundException;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class BikeConverter {
+
+	/**
+	 * BikeエンティティをBikeResponse DTOに変換します。
+	 * @param bike 変換元のBikeエンティティ
+	 * @return 変換されたBikeResponse DTO
+	 * @throws ResourceNotFoundException 指定されたバイクエンティティがnullの場合
+	 */
+	public BikeResponse convertToBikeResponse(Bike bike) {
+		if (bike == null) {
+			throw new ResourceNotFoundException("変換対象のバイクが見つかりません。");
+		}
+		return BikeResponse.builder()
+				.id(bike.getId())
+				.manufacturer(bike.getManufacturer())
+				.modelName(bike.getModelName())
+				.modelCode(bike.getModelCode())
+				.modelYear(bike.getModelYear())
+				.currentMileage(bike.getCurrentMileage())
+				.purchaseDate(bike.getPurchaseDate())
+				.imageUrl(bike.getImageUrl())
+				.createdAt(bike.getCreatedAt())
+				.updatedAt(bike.getUpdatedAt())
+				.userId(bike.getUser() != null ? bike.getUser().getId() : null)
+				.build();
+	}
+
+	/**
+	 * BikeCreateRequest DTOとUserエンティティからBikeエンティティを生成します。
+	 * 新規登録時の初期設定（createdAt, updatedAt, isDeleted）も行います。
+	 * @param request 変換元のBikeCreateRequest DTO
+	 * @param user バイクの所有者となるUserエンティティ
+	 * @return 変換されたBikeエンティティ
+	 */
+	public Bike convertToBikeEntity(BikeCreateRequest request, User user) {
+		if (request == null) {
+			throw new IllegalArgumentException("バイク作成リクエストがnullです。");
+		}
+		Bike bike = new Bike();
+		bike.setUser(user);
+		bike.setManufacturer(request.getManufacturer());
+		bike.setModelName(request.getModelName());
+		bike.setModelCode(request.getModelCode());
+		bike.setModelYear(request.getModelYear());
+		bike.setCurrentMileage(request.getCurrentMileage());
+		bike.setPurchaseDate(request.getPurchaseDate());
+		bike.setImageUrl(request.getImageUrl());
+
+		bike.setCreatedAt(LocalDateTime.now());
+		bike.setUpdatedAt(LocalDateTime.now());
+		bike.setDeleted(false);
+
+		return bike;
+	}
+
+	/**
+	 * BikeCreateRequest DTOの情報を既存のBikeエンティティにマッピングします。
+	 * 主に更新処理で使用します。
+	 * @param request 更新情報を含むBikeCreateRequest DTO
+	 * @param existingBike 更新対象の既存Bikeエンティティ
+	 * @return 更新されたBikeエンティティ
+	 * @throws IllegalArgumentException リクエストまたは既存バイクエンティティがnullの場合
+	 */
+	public Bike updateBikeEntityFromDto(BikeCreateRequest request, Bike existingBike) {
+		if (request == null || existingBike == null) {
+			throw new IllegalArgumentException("更新リクエストまたは既存のバイクエンティティがnullです。");
+		}
+		existingBike.setManufacturer(request.getManufacturer());
+		existingBike.setModelName(request.getModelName());
+		existingBike.setModelCode(request.getModelCode());
+		existingBike.setModelYear(request.getModelYear());
+		existingBike.setCurrentMileage(request.getCurrentMileage());
+		existingBike.setPurchaseDate(request.getPurchaseDate());
+		existingBike.setImageUrl(request.getImageUrl());
+
+		existingBike.setUpdatedAt(LocalDateTime.now());
+
+		return existingBike;
+	}
+}

--- a/src/main/java/com/rikuto/revox/dto/bike/BikeCreateRequest.java
+++ b/src/main/java/com/rikuto/revox/dto/bike/BikeCreateRequest.java
@@ -1,0 +1,53 @@
+
+package com.rikuto.revox.dto.bike;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BikeCreateRequest {
+
+	@NotNull(message = "ユーザーIDは必須です。")
+	@Min(value = 1, message = "ユーザーIDは1以上である必要があります。")
+	private Integer userId;
+
+	@NotBlank(message = "メーカー名は必須です。")
+	@Size(max = 50, message = "メーカー名は50文字以内で入力してください。")
+	private String manufacturer;
+
+	@NotBlank(message = "車両名は必須です。")
+	@Size(max = 100, message = "車両名は100文字以内で入力してください。")
+	private String modelName;
+
+	//型式はnull許容、入力する場合は文字数の制限があります。
+	@Size(max = 20, message = "型式は20文字以内で入力してください。")
+	private String modelCode;
+
+	// 年式はnull許容
+	private Integer modelYear;
+
+	// 走行距離はnull許容
+	@Min(value = 0, message = "走行距離は0以上である必要があります。")
+	private Integer currentMileage;
+
+	// 購入日はnull許容
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	private LocalDate purchaseDate;
+
+	@Size(max = 2048, message = "画像URLは2048文字以内で入力してください。")
+	private String imageUrl;
+}

--- a/src/main/java/com/rikuto/revox/dto/bike/BikeResponse.java
+++ b/src/main/java/com/rikuto/revox/dto/bike/BikeResponse.java
@@ -1,0 +1,30 @@
+package com.rikuto.revox.dto.bike;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BikeResponse {
+	private Integer id;
+	private String manufacturer;
+	private String modelName;
+	private String modelCode;
+	private Integer modelYear;
+	private Integer currentMileage;
+	private LocalDate purchaseDate;
+	private String imageUrl;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+
+	private Integer userId;
+}

--- a/src/main/java/com/rikuto/revox/entity/Bike.java
+++ b/src/main/java/com/rikuto/revox/entity/Bike.java
@@ -9,14 +9,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import lombok.Setter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -28,6 +27,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "bikes")
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
@@ -53,8 +53,6 @@ public class Bike {
 	 * 「ホンダ」「HONDA」などユーザーの好みの入力を受け付けます。
 	 */
 	@Column(name = "manufacturer", length = 50, nullable = false)
-	@Size(max = 50)
-	@NotBlank
 	private String manufacturer;
 
 	/**
@@ -62,8 +60,6 @@ public class Bike {
 	 * 「レブル」「Rebel」など好みの入力を受け付けます。
 	 */
 	@Column(name = "model_name", length = 100, nullable = false)
-	@Size(max = 100)
-	@NotBlank
 	private String modelName;
 
 	/**
@@ -71,7 +67,6 @@ public class Bike {
 	 * 分からないユーザーもいるためnullは許容しています。
 	 */
 	@Column(name = "model_code", length = 20)
-	@Size(max = 20)
 	private String modelCode;
 
 	/**
@@ -101,7 +96,6 @@ public class Bike {
 	 * 未入力でも許容するためnullを許容しています。
 	 */
 	@Column(name = "image_url", length = 2048)
-	@Size(max = 2048)
 	private String imageUrl;
 
 	/**

--- a/src/main/java/com/rikuto/revox/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/rikuto/revox/exception/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.rikuto.revox.exception; // または com.rikuto.revox.advice
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException; // バリデーションエラー用
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.context.support.DefaultMessageSourceResolvable; // エラーメッセージ取得用
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+	/**
+	 * ResourceNotFoundException を処理します。
+	 * リソースが見つからない場合に HTTP 404 Not Found を返します。
+	 * @param ex 発生した ResourceNotFoundException
+	 * @return エラーメッセージと HTTP 404 ステータス
+	 */
+	@ExceptionHandler(ResourceNotFoundException.class)
+	public ResponseEntity<String> handleResourceNotFoundException(ResourceNotFoundException ex) {
+		return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+	}
+
+	/**
+	 * @Valid によるバリデーションエラー (MethodArgumentNotValidException) を処理します。
+	 * 無効なリクエストボディが送信された場合に HTTP 400 Bad Request を返します。
+	 * @param ex 発生した MethodArgumentNotValidException
+	 * @return エラーメッセージのリストと HTTP 400 ステータス
+	 */
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<List<String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+		List<String> errors = ex.getBindingResult()
+				.getAllErrors()
+				.stream()
+				.map(DefaultMessageSourceResolvable::getDefaultMessage)
+				.collect(Collectors.toList());
+		return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+	}
+
+	/**
+	 * その他の予期せぬ例外を処理します。
+	 * アプリケーションで捕捉されなかったすべての例外に対して HTTP 500 Internal Server Error を返します。
+	 * @param ex 発生した例外
+	 * @return エラーメッセージと HTTP 500 ステータス
+	 */
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<String> handleAllUncaughtException(Exception ex) {
+		// 本番環境では、詳細なエラーメッセージをクライアントに直接返さず、ログに記録し、
+		// 汎用的なエラーメッセージを返すことを検討してください。
+		ex.printStackTrace(); // デバッグ目的でスタックトレースを出力
+		return new ResponseEntity<>("内部サーバーエラーが発生しました。", HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+}

--- a/src/main/java/com/rikuto/revox/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/rikuto/revox/exception/ResourceNotFoundException.java
@@ -1,0 +1,29 @@
+package com.rikuto.revox.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * リソースが見つからなかった場合にスローされるカスタム例外です。
+ * この例外がスローされると、HTTP 404 Not Found ステータスが返されます。
+ */
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+
+	/**
+	 * 指定された詳細メッセージを持つ新しい ResourceNotFoundException を構築します。
+	 * @param message 例外の詳細メッセージ
+	 */
+	public ResourceNotFoundException(String message) {
+		super(message);
+	}
+
+	/**
+	 * 指定された詳細メッセージと原因を持つ新しい ResourceNotFoundException を構築します。
+	 * @param message 例外の詳細メッセージ
+	 * @param cause この例外の原因となるThrowable (null可)
+	 */
+	public ResourceNotFoundException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/src/main/java/com/rikuto/revox/repository/BikeRepository.java
+++ b/src/main/java/com/rikuto/revox/repository/BikeRepository.java
@@ -4,7 +4,7 @@ import com.rikuto.revox.entity.Bike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.Optional;
 
 /**
  * バイクに関するリポジトリです。
@@ -18,5 +18,5 @@ public interface BikeRepository extends JpaRepository<Bike, Integer> {
 	 * @param userId 一意のユーザID
 	 * @return ユーザーに紐づいたバイク情報リスト
 	 */
-	List<Bike> findByUserIdAndIsDeletedFalse(Integer userId);
+	Optional<Bike> findByUserIdAndIsDeletedFalse(Integer userId);
 }

--- a/src/main/java/com/rikuto/revox/service/BikeService.java
+++ b/src/main/java/com/rikuto/revox/service/BikeService.java
@@ -1,0 +1,90 @@
+package com.rikuto.revox.service;
+
+import com.rikuto.revox.converter.BikeConverter;
+import com.rikuto.revox.dto.bike.BikeCreateRequest;
+import com.rikuto.revox.dto.bike.BikeResponse;
+import com.rikuto.revox.entity.Bike;
+import com.rikuto.revox.entity.User;
+import com.rikuto.revox.exception.ResourceNotFoundException;
+import com.rikuto.revox.repository.BikeRepository;
+import com.rikuto.revox.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+public class BikeService {
+
+	private final BikeRepository bikeRepository;
+	private final UserRepository userRepository;
+	private final BikeConverter bikeConverter;
+
+	public BikeService(UserRepository userRepository, BikeRepository bikeRepository, BikeConverter bikeConverter) {
+		this.userRepository = userRepository;
+		this.bikeRepository = bikeRepository;
+		this.bikeConverter = bikeConverter;
+	}
+
+	/**
+	 * ユーザーIDに紐づいたバイク情報の検索をします。
+	 * @param userId ユーザーID
+	 * @return 登録されたバイク情報（BikeResponse）
+	 * @throws ResourceNotFoundException 指定されたユーザーが見つからない場合
+	 */
+	public BikeResponse findBikeByUserId(Integer userId) {
+		Bike bike = bikeRepository.findByUserIdAndIsDeletedFalse(userId)
+				.orElseThrow(() -> new ResourceNotFoundException("User ID " + userId + " に紐づくバイクが見つかりません。"));
+		return bikeConverter.convertToBikeResponse(bike);
+	}
+
+	/**
+	 * 新しいバイク情報を登録します。
+	 * @param request 登録するバイク情報を含むリクエストDTO
+	 * @return 登録されたバイク情報（BikeResponse）
+	 * @throws ResourceNotFoundException 指定されたユーザーが見つからない場合
+	 */
+	@Transactional
+	public BikeResponse registerBike(BikeCreateRequest request) {
+		User user = userRepository.findById(request.getUserId())
+				.orElseThrow(() -> new ResourceNotFoundException("ユーザーID " + request.getUserId() + " が見つかりません。"));
+
+		Bike bike = bikeConverter.convertToBikeEntity(request, user);
+
+		Bike savedBike = bikeRepository.save(bike);
+		return bikeConverter.convertToBikeResponse(savedBike);
+	}
+
+	/**
+	 * 既存のバイク情報を更新します。
+	 * @param bikeId 更新するバイクのID
+	 * @param updatedBikeRequest 更新されたバイク情報を含むリクエストDTO
+	 * @return 更新されたバイク情報（BikeResponse）
+	 * @throws ResourceNotFoundException 指定されたバイクが見つからない場合
+	 */
+	@Transactional
+	public BikeResponse updateBike(Integer bikeId, BikeCreateRequest updatedBikeRequest) {
+		Bike existingBike = bikeRepository.findById(bikeId)
+				.orElseThrow(() -> new ResourceNotFoundException("バイクID " + bikeId + " が見つかりません。"));
+
+		Bike updated = bikeConverter.updateBikeEntityFromDto(updatedBikeRequest, existingBike);
+
+		Bike savedBike = bikeRepository.save(updated);
+		return bikeConverter.convertToBikeResponse(savedBike);
+	}
+
+	/**
+	 * 登録されているバイクを論理削除します。
+	 * @param bikeId 更新するバイクID
+	 * @throws ResourceNotFoundException 指定されたバイクが見つからない場合
+	 */
+	@Transactional
+	public void softDeleteBike(Integer bikeId) {
+		Bike existingBike = bikeRepository.findById(bikeId)
+				.orElseThrow(() -> new ResourceNotFoundException("バイクID " + bikeId + " が見つかりません。"));
+
+		existingBike.setDeleted(true);
+		existingBike.setUpdatedAt(LocalDateTime.now());
+		bikeRepository.save(existingBike);
+	}
+}


### PR DESCRIPTION
## 概要
本PRはバイク情報の基本的なCRUD操作機能の実装を行っています。

## 詳細
- serviceの実装
ドメイン設計ではユーザーとバイクは1：Nとなっています。今回ポートフォリオ作製にあたりMVPとして単一のバイク情報の保持へ設計変更を行いました。
 理由は複数台のバイク情報の管理をしたいユーザーよりも1台しか保有していないユーザーの方が多いこと、複数所有しているユーザー側もメインで管理しているバイクに対してまずは登録すると考えたためです。
今後機能拡張を想定した場合DB側では1：Nの設計とし、システム側で現状は単一の受付のみ可能とする実装にしたため変更範囲を限定させています。
またEntityとDTOでの変換処理に関してはconverterを作成し、責任の分離を行っています。

- controllerの実装
基本的なCRUD操作に対応したcontrollerの実装とHTTPステータスのレスポンスを行っています。

- converterの実装
レスポンスとして渡すためのEntityからDTOへ変換処理
登録時に受け取ったリクエスト内容をEntityへ変換
更新時に受け取ったリクエスト内容から保持しているEntity情報にマッピング
上記機能の実装を行っています

- 例外処理の実装
controlleradviceクラスの実装と独自例外の実装を行っています。
Bikeに限定した独自例外とはせずに～が見つからなかった場合の例外とすることで汎用性を持たせています

- DTOの実装
UserとBikeのEntityからrequestとresponseに必要な情報のみまとめたDTOを作成しています。