### PR TITLE
ダミーユーザーの作成とsecurityの削除

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ repositories {
 dependencies {
 	// Spring Boot Starters (Core Functionality)
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
@@ -54,7 +53,6 @@ dependencies {
 
 	// Test Dependencies
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'com.h2database:h2'
 }

--- a/src/main/java/com/rikuto/revox/service/BikeService.java
+++ b/src/main/java/com/rikuto/revox/service/BikeService.java
@@ -15,11 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class BikeService {
 
 	private final BikeRepository bikeRepository;
-	private final UserRepository userRepository;
+	private final UserService userService;
 	private final BikeMapper bikeMapper;
 
-	public BikeService(UserRepository userRepository, BikeRepository bikeRepository, BikeMapper bikeMapper) {
-		this.userRepository = userRepository;
+	public BikeService(UserService userService, BikeRepository bikeRepository, BikeMapper bikeMapper) {
+		this.userService = userService;
 		this.bikeRepository = bikeRepository;
 		this.bikeMapper = bikeMapper;
 	}
@@ -44,11 +44,8 @@ public class BikeService {
 	 */
 	@Transactional
 	public BikeResponse registerBike(BikeCreateRequest request) {
-		User user = userRepository.findById(request.getUserId())
-				.orElseThrow(() -> new ResourceNotFoundException("ユーザーID " + request.getUserId() + " が見つかりません。"));
-
+		User user = userService.findById(request.getUserId());
 		Bike bike = bikeMapper.toEntity(request, user);
-
 		Bike savedBike = bikeRepository.save(bike);
 		return bikeMapper.toResponse(savedBike);
 	}

--- a/src/main/java/com/rikuto/revox/service/UserService.java
+++ b/src/main/java/com/rikuto/revox/service/UserService.java
@@ -1,0 +1,21 @@
+package com.rikuto.revox.service;
+
+import com.rikuto.revox.entity.User;
+import com.rikuto.revox.exception.ResourceNotFoundException;
+import com.rikuto.revox.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+	private final UserRepository userRepository;
+
+	public UserService(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+
+	// IDで直接取得
+	public User findById(Integer userId) {
+		return userRepository.findByIdAndIsDeletedFalse(userId)
+				.orElseThrow(() -> new ResourceNotFoundException("ユーザーが見つかりません"));
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,6 @@ logging:
     root: INFO
     org:
       springframework:
-        security: DEBUG # 本番では通常 INFO にする
       hibernate:
         SQL: DEBUG      # 本番では通常 INFO にする
         type:
@@ -36,8 +35,3 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
-
-  security:
-    user:
-      name: ${SECURITY_USER_NAME}
-      password: ${SECURITY_USER_PASSWORD}

--- a/src/main/resources/db/migration/V006__Insert_initial_data.sql
+++ b/src/main/resources/db/migration/V006__Insert_initial_data.sql
@@ -1,0 +1,3 @@
+-- デモユーザー
+INSERT INTO users (id, nickname, email, created_at, updated_at) VALUES
+(1, 'デモユーザー', 'demo@example.com', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);

--- a/src/test/java/com/rikuto/revox/mapper/BikeConverterTest.java
+++ b/src/test/java/com/rikuto/revox/mapper/BikeConverterTest.java
@@ -1,5 +1,0 @@
-package com.rikuto.revox.mapper;
-
-class BikeConverterTest {
-
-}


### PR DESCRIPTION
## 概要
本PRはダミーのテストユーザーの作成を行っています

## 変更理由
当初springsecurityの学習を行い認証認可の実装を予定していました。
制作時間の関係からまずは動作するものを制作するためspringsecurityを削除し、マイグレーションスクリプトにてテストユーザーの導入を行いました。

Entityおよびrepositoryは今後認証機能実装時に使用するため削除せずに残しています