### PR TITLE
整備タスク機能の実装

### DIFF
--- a/src/main/java/com/rikuto/revox/controller/MaintenanceTaskController.java
+++ b/src/main/java/com/rikuto/revox/controller/MaintenanceTaskController.java
@@ -1,0 +1,79 @@
+package com.rikuto.revox.controller;
+
+import com.rikuto.revox.dto.maintenancetask.MaintenanceTaskRequest;
+import com.rikuto.revox.dto.maintenancetask.MaintenanceTaskResponse;
+import com.rikuto.revox.service.MaintenanceTaskService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/maintenance-task")
+public class MaintenanceTaskController {
+
+	private final MaintenanceTaskService maintenanceTaskService;
+
+	public MaintenanceTaskController(MaintenanceTaskService maintenanceTaskService) {
+		this.maintenanceTaskService = maintenanceTaskService;
+	}
+
+	/**
+	 * カテゴリーIDで整備タスクの検索を行います。
+	 *
+	 * @param categoryId カテゴリーID
+	 * @return 整備タスク情報とHttpステータス　200　OK
+	 */
+	@GetMapping("/category/{categoryId}")
+	public ResponseEntity<List<MaintenanceTaskResponse>> getMaintenanceTaskBycategoryId(@PathVariable Integer categoryId) {
+		List<MaintenanceTaskResponse> maintenanceTaskResponse = maintenanceTaskService.findMaintenanceTaskByCategoryId(categoryId);
+		return ResponseEntity.ok(maintenanceTaskResponse);
+	}
+
+	/**
+	 * 整備タスクの新規登録を行います。
+	 *
+	 * @param request 登録する整備タスク情報
+	 * @return 登録済の整備タスク情報とHttpステータス　201
+	 */
+	@PostMapping
+	public ResponseEntity<MaintenanceTaskResponse> registerMaintenanceTask(@RequestBody @Valid MaintenanceTaskRequest request) {
+		MaintenanceTaskResponse registeredMaintenanceTask = maintenanceTaskService.registerMaintenanceTask(request);
+		return new ResponseEntity<>(registeredMaintenanceTask, HttpStatus.CREATED);
+	}
+
+	/**
+	 * 整備タスクの更新を行います。
+	 *
+	 * @param maintenanceTaskId 整備タスクID
+	 * @param request 更新する内容の整備タスク
+	 * @return 更新後の整備タスク情報とHttpステータス　200　ok
+	 */
+	@PutMapping("/{maintenanceTaskId}")
+	public ResponseEntity<MaintenanceTaskResponse> updateMaintenanceTask(@PathVariable Integer maintenanceTaskId,
+	                                                                     @RequestBody @Valid MaintenanceTaskRequest request) {
+		MaintenanceTaskResponse maintenanceTaskResponse = maintenanceTaskService.updateMaintenanceTask(maintenanceTaskId, request);
+		return ResponseEntity.ok(maintenanceTaskResponse);
+	}
+
+	/**
+	 * 整備タスクの論理削除を行います。
+	 *
+	 * @param maintenanceTaskId 整備タスクID
+	 * @return Httpステータス　204
+	 */
+	@DeleteMapping("/{maintenanceTaskId}")
+	public ResponseEntity<Void> softDeleteMaintenanceTask(@PathVariable Integer maintenanceTaskId) {
+		maintenanceTaskService.softDeleteMaintenanceTask(maintenanceTaskId);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/com/rikuto/revox/domain/AiQuestion.java
+++ b/src/main/java/com/rikuto/revox/domain/AiQuestion.java
@@ -1,4 +1,4 @@
-package com.rikuto.revox.entity;
+package com.rikuto.revox.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/rikuto/revox/domain/Bike.java
+++ b/src/main/java/com/rikuto/revox/domain/Bike.java
@@ -1,4 +1,4 @@
-package com.rikuto.revox.entity;
+package com.rikuto.revox.domain;
 
 import com.rikuto.revox.dto.bike.BikeCreateRequest;
 import jakarta.persistence.Column;

--- a/src/main/java/com/rikuto/revox/domain/Category.java
+++ b/src/main/java/com/rikuto/revox/domain/Category.java
@@ -1,4 +1,4 @@
-package com.rikuto.revox.entity;
+package com.rikuto.revox.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/rikuto/revox/domain/User.java
+++ b/src/main/java/com/rikuto/revox/domain/User.java
@@ -1,4 +1,4 @@
-package com.rikuto.revox.entity;
+package com.rikuto.revox.domain;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;

--- a/src/main/java/com/rikuto/revox/dto/maintenancetask/MaintenanceTaskRequest.java
+++ b/src/main/java/com/rikuto/revox/dto/maintenancetask/MaintenanceTaskRequest.java
@@ -9,11 +9,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * ユーザーから受け取る整備タスクの内容です。
+ * 各フィールドにはバリデーションがあります。
+ */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class MaintenanceTaskCreateRequest {
+public class MaintenanceTaskRequest {
 
 	@NotNull(message = "カテゴリーIDは必須です。")
 	@Min(value = 1, message = "カテゴリーIDは1以上である必要があります。")
@@ -23,7 +27,7 @@ public class MaintenanceTaskCreateRequest {
 	@Size(max = 100, message = "タスク名は100文字以内で入力してください。")
 	private String name;
 
-	// nullを許容（AIで後から生成する場合もある）
-	@Size(max = 5000, message = "詳細は5000文字以内で入力してください。")
+	@NotBlank(message = "詳細内容は必須です。")
+	@Size(max = 5000, message = "質問内容は5000文字以内で入力してください。")
 	private String description;
 }

--- a/src/main/java/com/rikuto/revox/dto/maintenancetask/MaintenanceTaskResponse.java
+++ b/src/main/java/com/rikuto/revox/dto/maintenancetask/MaintenanceTaskResponse.java
@@ -7,6 +7,10 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+/**
+ * 内部処理を行った後ユーザーへ返すレスポンス内容のDTOです。
+ *
+ */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -14,10 +18,10 @@ import java.time.LocalDateTime;
 public class MaintenanceTaskResponse {
 
 	private Integer id;
-	private Integer categoryId;
-	private String categoryName; // カテゴリー名も含める
 	private String name;
 	private String description;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
+
+	private Integer categoryId;
 }

--- a/src/main/java/com/rikuto/revox/mapper/AiQuestionMapper.java
+++ b/src/main/java/com/rikuto/revox/mapper/AiQuestionMapper.java
@@ -2,11 +2,10 @@ package com.rikuto.revox.mapper;
 
 import com.rikuto.revox.dto.aiquestion.AiQuestionCreateRequest;
 import com.rikuto.revox.dto.aiquestion.AiQuestionResponse;
-import com.rikuto.revox.entity.AiQuestion;
-import com.rikuto.revox.entity.Bike;
-import com.rikuto.revox.entity.Category;
-import com.rikuto.revox.entity.User;
-import com.rikuto.revox.exception.ResourceNotFoundException;
+import com.rikuto.revox.domain.AiQuestion;
+import com.rikuto.revox.domain.Bike;
+import com.rikuto.revox.domain.Category;
+import com.rikuto.revox.domain.User;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/rikuto/revox/mapper/BikeMapper.java
+++ b/src/main/java/com/rikuto/revox/mapper/BikeMapper.java
@@ -2,8 +2,8 @@ package com.rikuto.revox.mapper;
 
 import com.rikuto.revox.dto.bike.BikeCreateRequest;
 import com.rikuto.revox.dto.bike.BikeResponse;
-import com.rikuto.revox.entity.Bike;
-import com.rikuto.revox.entity.User;
+import com.rikuto.revox.domain.Bike;
+import com.rikuto.revox.domain.User;
 import com.rikuto.revox.exception.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/rikuto/revox/mapper/MaintenanceTaskMapper.java
+++ b/src/main/java/com/rikuto/revox/mapper/MaintenanceTaskMapper.java
@@ -1,0 +1,61 @@
+package com.rikuto.revox.mapper;
+
+import com.rikuto.revox.dto.maintenancetask.MaintenanceTaskRequest;
+import com.rikuto.revox.dto.maintenancetask.MaintenanceTaskResponse;
+import com.rikuto.revox.domain.Category;
+import com.rikuto.revox.domain.MaintenanceTask;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * MaintenanceTaskエンティティと関連するDTOの相互変換を担うクラスです。
+ * ドメインの振る舞い（更新・削除などのロジック）は保持せず、純粋なデータ変換に専念します。
+ */
+@Component
+public class MaintenanceTaskMapper {
+
+	/**
+	 * ユーザーへレスポンスする内容へ変換します。
+	 * @param task 整備タスク情報
+	 * @return フロント側へ渡す単一の整備タスク情報
+	 */
+	public MaintenanceTaskResponse toResponse(MaintenanceTask task) {
+		return MaintenanceTaskResponse.builder()
+				.id(task.getId())
+				.name(task.getName())
+				.description(task.getDescription())
+				.createdAt(task.getCreatedAt())
+				.updatedAt(task.getUpdatedAt())
+				.categoryId(task.getCategory() != null ? task.getCategory().getId() : null)
+				.build();
+	}
+
+	/**
+	 * ユーザーへレスポンスする内容へ変換します。
+	 * 整備タスクをList化します
+	 *
+	 * @param maintenanceTaskList 複数の整備タスク
+	 * @return List化された整備タスク
+	 */
+	public List<MaintenanceTaskResponse> toResponseList(List<MaintenanceTask> maintenanceTaskList) {
+		return maintenanceTaskList.stream()
+				.map(this::toResponse)
+				.toList();
+	}
+
+
+	/**
+	 * 受け取ったリクエスト情報をEntityに変換します
+	 * @param request リクエストとして受け取った整備タスク情報
+	 * @param category カテゴリー情報
+	 * @return Entity情報
+	 */
+	public MaintenanceTask toEntity (MaintenanceTaskRequest request, Category category) {
+	return MaintenanceTask.builder()
+			.name(request.getName())
+			.category(category)
+			.description(request.getDescription())
+			.build();
+	}
+}

--- a/src/main/java/com/rikuto/revox/repository/AiQuestionRepository.java
+++ b/src/main/java/com/rikuto/revox/repository/AiQuestionRepository.java
@@ -1,6 +1,6 @@
 package com.rikuto.revox.repository;
 
-import com.rikuto.revox.entity.AiQuestion;
+import com.rikuto.revox.domain.AiQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import java.util.List;

--- a/src/main/java/com/rikuto/revox/repository/BikeRepository.java
+++ b/src/main/java/com/rikuto/revox/repository/BikeRepository.java
@@ -1,6 +1,6 @@
 package com.rikuto.revox.repository;
 
-import com.rikuto.revox.entity.Bike;
+import com.rikuto.revox.domain.Bike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/rikuto/revox/repository/CategoryRepository.java
+++ b/src/main/java/com/rikuto/revox/repository/CategoryRepository.java
@@ -1,6 +1,6 @@
 package com.rikuto.revox.repository;
 
-import com.rikuto.revox.entity.Category;
+import com.rikuto.revox.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/rikuto/revox/repository/MaintenanceTaskRepository.java
+++ b/src/main/java/com/rikuto/revox/repository/MaintenanceTaskRepository.java
@@ -1,6 +1,6 @@
 package com.rikuto.revox.repository;
 
-import com.rikuto.revox.entity.MaintenanceTask;
+import com.rikuto.revox.domain.MaintenanceTask;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/rikuto/revox/repository/UserRepository.java
+++ b/src/main/java/com/rikuto/revox/repository/UserRepository.java
@@ -1,6 +1,6 @@
 package com.rikuto.revox.repository;
 
-import com.rikuto.revox.entity.User;
+import com.rikuto.revox.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/rikuto/revox/service/AiQuestionService.java
+++ b/src/main/java/com/rikuto/revox/service/AiQuestionService.java
@@ -2,10 +2,10 @@ package com.rikuto.revox.service;
 
 import com.rikuto.revox.dto.aiquestion.AiQuestionCreateRequest;
 import com.rikuto.revox.dto.aiquestion.AiQuestionResponse;
-import com.rikuto.revox.entity.AiQuestion;
-import com.rikuto.revox.entity.Bike;
-import com.rikuto.revox.entity.Category;
-import com.rikuto.revox.entity.User;
+import com.rikuto.revox.domain.AiQuestion;
+import com.rikuto.revox.domain.Bike;
+import com.rikuto.revox.domain.Category;
+import com.rikuto.revox.domain.User;
 import com.rikuto.revox.exception.ResourceNotFoundException;
 import com.rikuto.revox.mapper.AiQuestionMapper;
 import com.rikuto.revox.repository.AiQuestionRepository;

--- a/src/main/java/com/rikuto/revox/service/AiQuestionService.java
+++ b/src/main/java/com/rikuto/revox/service/AiQuestionService.java
@@ -41,9 +41,9 @@ public class AiQuestionService {
 		User user = userRepository.findByIdAndIsDeletedFalse(request.getUserId())
 				.orElseThrow(() -> new ResourceNotFoundException("ユーザーID " + request.getUserId() + " が見つかりません。"));
 		Bike bike = bikeRepository.findByUserIdAndIsDeletedFalse(request.getBikeId())
-				.orElseThrow(() -> new ResourceNotFoundException("ユーザーID " + request.getUserId() + " が見つかりません。"));
+				.orElseThrow(() -> new ResourceNotFoundException("バイクID " + request.getBikeId() + " が見つかりません。"));
 		Category category = categoryRepository.findById(request.getCategoryId())
-				.orElseThrow(() -> new ResourceNotFoundException("ユーザーID " + request.getUserId() + " が見つかりません。"));
+				.orElseThrow(() -> new ResourceNotFoundException("カテゴリーID " + request.getCategoryId() + " が見つかりません。"));
 
 //ToDo		ここに動的に回答を生成させる
 		String aiAnswer = generateAiAnswer(request.getQuestion(), bike, category);

--- a/src/main/java/com/rikuto/revox/service/BikeService.java
+++ b/src/main/java/com/rikuto/revox/service/BikeService.java
@@ -3,11 +3,10 @@ package com.rikuto.revox.service;
 import com.rikuto.revox.mapper.BikeMapper;
 import com.rikuto.revox.dto.bike.BikeCreateRequest;
 import com.rikuto.revox.dto.bike.BikeResponse;
-import com.rikuto.revox.entity.Bike;
-import com.rikuto.revox.entity.User;
+import com.rikuto.revox.domain.Bike;
+import com.rikuto.revox.domain.User;
 import com.rikuto.revox.exception.ResourceNotFoundException;
 import com.rikuto.revox.repository.BikeRepository;
-import com.rikuto.revox.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/rikuto/revox/service/MaintenanceTaskService.java
+++ b/src/main/java/com/rikuto/revox/service/MaintenanceTaskService.java
@@ -1,0 +1,95 @@
+package com.rikuto.revox.service;
+
+import com.rikuto.revox.dto.maintenancetask.MaintenanceTaskRequest;
+import com.rikuto.revox.dto.maintenancetask.MaintenanceTaskResponse;
+import com.rikuto.revox.domain.Category;
+import com.rikuto.revox.domain.MaintenanceTask;
+import com.rikuto.revox.exception.ResourceNotFoundException;
+import com.rikuto.revox.mapper.MaintenanceTaskMapper;
+import com.rikuto.revox.repository.CategoryRepository;
+import com.rikuto.revox.repository.MaintenanceTaskRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 整備タスク情報を表すエンティティです。
+ * データベースのmaintenance_tasksテーブルにマッピングされています。
+ * ドメインモデルの一部として、タスクのビジネスロジックや整合性を管理します。
+ */
+@Service
+public class MaintenanceTaskService {
+
+	private final MaintenanceTaskRepository maintenanceTaskRepository;
+	private final MaintenanceTaskMapper maintenanceTaskMapper;
+	private final CategoryRepository categoryRepository;
+
+	public MaintenanceTaskService(MaintenanceTaskRepository maintenanceTaskRepository, MaintenanceTaskMapper maintenanceTaskMapper, CategoryRepository categoryRepository) {
+		this.maintenanceTaskRepository = maintenanceTaskRepository;
+		this.maintenanceTaskMapper = maintenanceTaskMapper;
+		this.categoryRepository = categoryRepository;
+	}
+
+	/**
+	 * カテゴリーIDに紐づいた整備タスクの検索機能です。
+	 * 複数のタスクをMapperで変換処理します。
+	 * 空のListの場合もそのまま処理します。
+	 *
+	 * @param categoryId カテゴリーID
+	 * @return レスポンスへ返還後の整備タスク
+	 */
+	public List<MaintenanceTaskResponse> findMaintenanceTaskByCategoryId(Integer categoryId) {
+		List<MaintenanceTask> maintenanceTask = maintenanceTaskRepository.findByCategoryIdAndIsDeletedFalse(categoryId);
+		return maintenanceTaskMapper.toResponseList(maintenanceTask);
+	}
+
+	/**
+	 * カテゴリーIDに紐づけて整備タスクを新規登録します。
+	 *
+	 * @param request 登録する整備タスクのリクエスト情報
+	 * @return 登録後の整備タスク情報
+	 */
+	@Transactional
+	public MaintenanceTaskResponse registerMaintenanceTask(MaintenanceTaskRequest request) {
+		Category category = categoryRepository.findById(request.getCategoryId())
+				.orElseThrow(() -> new ResourceNotFoundException("カテゴリーID " + request.getCategoryId() + " が見つかりません。"));
+
+		MaintenanceTask maintenanceTask = maintenanceTaskMapper.toEntity(request, category);
+		MaintenanceTask savedTask = maintenanceTaskRepository.save(maintenanceTask);
+		return maintenanceTaskMapper.toResponse(savedTask);
+	}
+
+	/**
+	 * 整備タスクの更新を行います。
+	 * 更新処理はdomainで行い、mapperで変換します。
+	 *
+	 * @param maintenanceTaskId 整備タスクID
+	 * @param updateMaintenance 更新するリクエスト情報
+	 * @return 更新後の整備タスク情報
+	 */
+	@Transactional
+	public MaintenanceTaskResponse updateMaintenanceTask(Integer maintenanceTaskId , MaintenanceTaskRequest updateMaintenance) {
+		MaintenanceTask existingMaintenanceTask = maintenanceTaskRepository.findById(maintenanceTaskId)
+				.orElseThrow(() -> new ResourceNotFoundException("整備タスクID " + maintenanceTaskId + " が見つかりません。"));
+
+		existingMaintenanceTask.updateFrom(updateMaintenance);
+		maintenanceTaskRepository.save(existingMaintenanceTask);
+		return maintenanceTaskMapper.toResponse(existingMaintenanceTask);
+	}
+
+	/**
+	 * 整備タスクの論理削除を行います。
+	 * 論理削除の変換操作はdomainで行います。
+	 *
+	 * @param maintenanceTaskId 整備タスクID
+	 */
+	@Transactional
+	public void softDeleteMaintenanceTask(Integer maintenanceTaskId) {
+		MaintenanceTask existingMaintenanceTask = maintenanceTaskRepository.findById(maintenanceTaskId)
+				.orElseThrow(() -> new ResourceNotFoundException("整備タスクID " + maintenanceTaskId + " が見つかりません。"));
+
+		existingMaintenanceTask.softDelete();
+		maintenanceTaskRepository.save(existingMaintenanceTask);
+	}
+}

--- a/src/main/java/com/rikuto/revox/service/UserService.java
+++ b/src/main/java/com/rikuto/revox/service/UserService.java
@@ -1,6 +1,6 @@
 package com.rikuto.revox.service;
 
-import com.rikuto.revox.entity.User;
+import com.rikuto.revox.domain.User;
 import com.rikuto.revox.exception.ResourceNotFoundException;
 import com.rikuto.revox.repository.UserRepository;
 import org.springframework.stereotype.Service;

--- a/src/test/java/com/rikuto/revox/repository/BikeRepositoryTest.java
+++ b/src/test/java/com/rikuto/revox/repository/BikeRepositoryTest.java
@@ -1,14 +1,13 @@
 package com.rikuto.revox.repository;
 
-import com.rikuto.revox.entity.Bike;
-import com.rikuto.revox.entity.User;
+import com.rikuto.revox.domain.Bike;
+import com.rikuto.revox.domain.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/rikuto/revox/repository/MaintenanceTaskRepositoryTest.java
+++ b/src/test/java/com/rikuto/revox/repository/MaintenanceTaskRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.rikuto.revox.repository;
 
-import com.rikuto.revox.entity.Category;
-import com.rikuto.revox.entity.MaintenanceTask;
+import com.rikuto.revox.domain.Category;
+import com.rikuto.revox.domain.MaintenanceTask;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/rikuto/revox/repository/UserRepositoryTest.java
+++ b/src/test/java/com/rikuto/revox/repository/UserRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.rikuto.revox.repository;
 
-import com.rikuto.revox.entity.User;
+import com.rikuto.revox.domain.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/rikuto/revox/service/BikeServiceTest.java
+++ b/src/test/java/com/rikuto/revox/service/BikeServiceTest.java
@@ -2,8 +2,8 @@ package com.rikuto.revox.service;
 
 import com.rikuto.revox.dto.bike.BikeCreateRequest;
 import com.rikuto.revox.dto.bike.BikeResponse;
-import com.rikuto.revox.entity.Bike;
-import com.rikuto.revox.entity.User;
+import com.rikuto.revox.domain.Bike;
+import com.rikuto.revox.domain.User;
 import com.rikuto.revox.exception.ResourceNotFoundException;
 import com.rikuto.revox.mapper.BikeMapper;
 import com.rikuto.revox.repository.BikeRepository;


### PR DESCRIPTION
## 概要
整備タスク機能の実装を行っています。
パッケージ名の変更に伴い他クラスの差分が含まれています

## やったこと
- 整備タスク機能の実装
サービス、コントローラー、マッパー、ドメインの実装
- ドメイン変更
mapperでの変換処理を実装する際、更新および削除のロジックに対する取り扱いについて検討をしました。
現在のmapperはEntityとDTOのマッピングを行うクラスとなっています。
ここに更新・削除のロジックを含めることの是非について考察したところEntityからdomainへ変更しどDDD設計を取り入れることでsetterを使用しない設計にすることができました。