### PR TITLE
外部AI　APIの連携の実装とテストの修正

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'com.h2database:h2'
+
+	// Google Generative AI SDK
+	implementation 'com.google.genai:google-genai:1.10.0'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/src/main/java/com/rikuto/revox/dto/aiquestion/AiQuestionPrompt.java
+++ b/src/main/java/com/rikuto/revox/dto/aiquestion/AiQuestionPrompt.java
@@ -1,0 +1,31 @@
+package com.rikuto.revox.dto.aiquestion;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/**
+ * AIへバイク情報を渡すためのDTOです。
+ * DBへ登録時に入力チェックを行っているため、このDTOにはバリデーションはありません。
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AiQuestionPrompt {
+
+	private String manufacturer;
+	private String modelName;
+	private String modelCode;
+	private Integer modelYear;
+	private Integer currentMileage;
+	private LocalDate purchaseDate;
+
+	private String question;
+
+	private Integer categoryId;
+
+}

--- a/src/main/java/com/rikuto/revox/service/GeminiService.java
+++ b/src/main/java/com/rikuto/revox/service/GeminiService.java
@@ -1,0 +1,91 @@
+package com.rikuto.revox.service;
+
+import com.google.genai.Client;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.HttpOptions;
+import com.google.genai.types.Part;
+import com.rikuto.revox.dto.aiquestion.AiQuestionPrompt;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class GeminiService {
+
+	private final Client client;
+
+	public GeminiService() {
+		try {
+			String projectId = Optional.ofNullable(System.getenv("GOOGLE_CLOUD_PROJECT"))
+					.orElseThrow(() -> new IllegalArgumentException("GOOGLE_CLOUD_PROJECT environment variable not set."));
+			String location = Optional.ofNullable(System.getenv("GOOGLE_CLOUD_LOCATION"))
+					.orElseThrow(() -> new IllegalArgumentException("GOOGLE_CLOUD_LOCATION environment variable not set."));
+
+			this.client = Client.builder()
+					.project(projectId)
+					.location(location)
+					.vertexAI(true)
+					.httpOptions(HttpOptions.builder().apiVersion("v1").build())
+					.build();
+		} catch (Exception e) {
+			throw new RuntimeException("GenaiClientの作成に失敗しました。", e);
+		}
+	}
+
+	public String generateContent(AiQuestionPrompt prompt) {
+		// AIに役割を与えるシステム命令を設定（キャラ設定など）
+		String systemInstructionText = "あなたはバイクの専門家です。提供されたバイクの情報とユーザーの質問に基づき、正確・具体的かつ整備初心者にわかりやすく回答してください。";
+		//AIが理解できるオブジェクトに変換
+		Content systemInstruction = Content.fromParts(Part.fromText(systemInstructionText));
+
+		StringBuilder promptBuilder = getStringBuilder(prompt);
+
+		// プロンプトをContentオブジェクトにラップ
+		Content userContent = Content.fromParts(Part.fromText(promptBuilder.toString()));
+
+		// GenerateContentConfigを作成し、システム命令を設定
+		GenerateContentConfig config = GenerateContentConfig.builder()
+				.systemInstruction(systemInstruction)
+				.build();
+
+		try {
+			// client.models.generateContent()を使ってAPIを呼び出す
+			GenerateContentResponse response = client.models.generateContent(
+					"gemini-2.5-flash",
+					userContent,//ラップしたプロンプト
+					config
+			);
+			return response.text();
+		} catch (Exception e) {
+			return "AIからの回答生成中にエラーが発生しました。";
+		}
+	}
+
+	@NotNull
+	private static StringBuilder getStringBuilder(AiQuestionPrompt prompt) {
+		StringBuilder promptBuilder = new StringBuilder();
+		promptBuilder.append("バイク情報:\n");
+
+		promptBuilder.append(String.format("- メーカー: %s\n", prompt.getManufacturer()));
+		promptBuilder.append(String.format("- モデル名: %s\n", prompt.getModelName()));
+
+		if (prompt.getModelCode() != null) {
+			promptBuilder.append(String.format("- モデルコード: %s\n", prompt.getModelCode()));
+		}
+		if (prompt.getModelYear() != null) {
+			promptBuilder.append(String.format("- 年式: %s\n", prompt.getModelYear()));
+		}
+		if (prompt.getCurrentMileage() != null) {
+			promptBuilder.append(String.format("- 現在の走行距離: %s km\n", prompt.getCurrentMileage()));
+		}
+		if (prompt.getPurchaseDate() != null) {
+			promptBuilder.append(String.format("- 購入日: %s\n", prompt.getPurchaseDate()));
+		}
+
+		promptBuilder.append(String.format("\n質問内容: %s", prompt.getQuestion()));
+		return promptBuilder;
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,9 +36,14 @@ spring:
     enabled: true
     locations: classpath:db/migration
 
-
     mvc:
       cors:
         allowed-origins: "http://localhost:3000"
         allowed-methods: "GET,POST,PUT,DELETE,OPTIONS"
         allowed-headers: "*"
+
+    gemini:
+      model: "gemini-2.5-flash"
+      project-id: ${GOOGLE_CLOUD_PROJECT}
+      location: ${GOOGLE_CLOUD_LOCATION:us-central1}
+      system-instruction: "あなたはバイクの専門家です..."

--- a/src/test/java/com/rikuto/revox/service/AiQuestionServiceTest.java
+++ b/src/test/java/com/rikuto/revox/service/AiQuestionServiceTest.java
@@ -5,6 +5,7 @@ import com.rikuto.revox.domain.Bike;
 import com.rikuto.revox.domain.Category;
 import com.rikuto.revox.domain.User;
 import com.rikuto.revox.dto.aiquestion.AiQuestionCreateRequest;
+import com.rikuto.revox.dto.aiquestion.AiQuestionPrompt;
 import com.rikuto.revox.dto.aiquestion.AiQuestionResponse;
 import com.rikuto.revox.exception.ResourceNotFoundException;
 import com.rikuto.revox.mapper.AiQuestionMapper;
@@ -27,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,6 +49,10 @@ class AiQuestionServiceTest {
 
 	@Mock
 	private AiQuestionMapper aiQuestionMapper;
+
+	@Mock
+	private GeminiService geminiService;
+
 
 	@InjectMocks
 	private AiQuestionService aiQuestionService;
@@ -125,6 +131,7 @@ class AiQuestionServiceTest {
 			stubBikeFound();
 			stubCategoryFound();
 
+			when(geminiService.generateContent(any(AiQuestionPrompt.class))).thenReturn("Mocked AI Answer");
 			when(aiQuestionMapper.toEntity(any(), any(), any(), any(), any())).thenReturn(testAiQuestion);
 			when(aiQuestionRepository.save(testAiQuestion)).thenReturn(testAiQuestion);
 			when(aiQuestionMapper.toResponse(testAiQuestion)).thenReturn(commonAiQuestionResponse);
@@ -138,6 +145,7 @@ class AiQuestionServiceTest {
 			verify(aiQuestionMapper).toEntity(any(), any(), any(), any(), any());
 			verify(aiQuestionRepository).save(testAiQuestion);
 			verify(aiQuestionMapper).toResponse(testAiQuestion);
+			verify(geminiService,times(1)).generateContent(any(AiQuestionPrompt.class));
 		}
 
 		@Test


### PR DESCRIPTION
## 概要
Gemini　APIの実装を行っています。
promptには現状バイクの専門家であり初心者へレクチャーするよう指示を出しており、ユーザーの登録車両の情報も同時に提供することでユーザーの質問へ返答するよう設計しています

## やったこと
- application.ymlにGeminiの設定を記述
- GeminiServiceの実装
APIの認証およびリクエスト情報とユーザー情報から回答を生成する機能の実装を行っています。
Geminiのモデルは2.5-flash、エンドポイントは安定版のv1です
- GeminiServiceへの情報提供のためのDTOを実装
呼びだし元で必要情報の絞り込み（IDで）を行いDBから取得してきた情報をGeminiServiceにある生成メソッドへ渡すためのDTOです。
- AiQuestionServiceの修正
静的な回答での実装を行っていましたが、外部API実装による動的回答を実装しています。
- テストの修正
AiQuestionServiceのテストは静的な回答で実装していたため、これを動的に変更するためGeminiServiceをMock化し修正しています。