### PR TITLE
Google認証機能の実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,70 +1,74 @@
 plugins {
-	id 'java'
-	id 'war'
-	id 'org.springframework.boot' version '3.5.3'
-	id 'io.spring.dependency-management' version '1.1.7'
-	id 'org.flywaydb.flyway' version '9.22.3'
+    id 'java'
+    id 'war'
+    id 'org.springframework.boot' version '3.5.3'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.flywaydb.flyway' version '9.22.3'
 }
 
 group = 'com.rikuto.revox'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	// Spring Boot Starters (Core Functionality)
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+    // --- Spring Boot Core & Web ---
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	// Database Migration
-	implementation 'org.flywaydb:flyway-core'
-	implementation 'org.flywaydb:flyway-mysql'
+    // --- 認証・認可 (Security) ---
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    implementation 'org.springframework.security:spring-security-oauth2-jose'
+    // JWTライブラリ (jjwt)
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	// Compile-time only
-	compileOnly 'org.projectlombok:lombok'
+    // --- データベース (Database) ---
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	// Development Tools
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    // --- 開発・補助ツール (Development & Tools) ---
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	// Runtime Drivers
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    // --- 提供されるランタイム (Provided Runtime) ---
+    providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
 
-	// Annotation Processors
-	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-	annotationProcessor 'org.projectlombok:lombok'
+    // --- テスト (Test) ---
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'com.h2database:h2'
 
-	// Provided Runtime (e.g., for WAR deployments)
-	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
-
-	// Test Dependencies
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testImplementation 'com.h2database:h2'
-
-	// Google Generative AI SDK
-	implementation 'com.google.genai:google-genai:1.10.0'
+    // --- 外部サービス連携 (External Services) ---
+    implementation 'com.google.genai:google-genai:1.10.0'
+    implementation 'com.google.api-client:google-api-client:2.2.0'
 }
 
 tasks.withType(JavaCompile).configureEach {
-	options.encoding = "UTF-8"
+    options.encoding = "UTF-8"
 }
 
 tasks.test {
-	useJUnitPlatform()
-	jvmArgs += "-javaagent:${classpath.find { it.name.contains("byte-buddy-agent") }.absolutePath}"
+    useJUnitPlatform()
+    jvmArgs += "-javaagent:${classpath.find { it.name.contains("byte-buddy-agent") }.absolutePath}"
 }

--- a/src/main/java/com/rikuto/revox/controller/AuthUserController.java
+++ b/src/main/java/com/rikuto/revox/controller/AuthUserController.java
@@ -1,0 +1,37 @@
+package com.rikuto.revox.controller;
+
+import com.rikuto.revox.dto.auth.LoginRequest;
+import com.rikuto.revox.dto.auth.LoginResponse;
+import com.rikuto.revox.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 外部認証専用の認証コントローラーです。
+ */
+@RestController
+@RequestMapping("/api/auth")
+public class AuthUserController {
+
+	private final AuthService authService;
+
+	public AuthUserController(AuthService authService) {
+		this.authService = authService;
+	}
+
+	/**
+	 * Google認証でのログイン
+	 *
+	 * @param request Google IDトークンを含むリクエスト
+	 * @return JWTトークンとユーザー情報
+	 */
+	@PostMapping("/google")
+	public ResponseEntity<LoginResponse> loginWithGoogle(@Valid @RequestBody LoginRequest request) {
+		LoginResponse response = authService.loginWithGoogle(request.idToken());
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/com/rikuto/revox/dto/auth/GoogleTokenPayload.java
+++ b/src/main/java/com/rikuto/revox/dto/auth/GoogleTokenPayload.java
@@ -1,0 +1,15 @@
+package com.rikuto.revox.dto.auth;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Google IDトークンのペイロード情報を保持するDTOです。
+ */
+@Getter
+@Builder
+public class GoogleTokenPayload {
+	private final String sub;
+	private final String email;
+	private final String name;
+}

--- a/src/main/java/com/rikuto/revox/dto/auth/LoginRequest.java
+++ b/src/main/java/com/rikuto/revox/dto/auth/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.rikuto.revox.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Google認証リクエストDTOです。
+ */
+public record LoginRequest(
+		@NotBlank(message = "Google IDトークンは必須です。")
+		String idToken
+) {}

--- a/src/main/java/com/rikuto/revox/dto/auth/LoginResponse.java
+++ b/src/main/java/com/rikuto/revox/dto/auth/LoginResponse.java
@@ -1,0 +1,16 @@
+package com.rikuto.revox.dto.auth;
+
+import com.rikuto.revox.dto.user.UserResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * ログイン結果をフロントへ渡すためのDTOです。
+ */
+@Getter
+@Builder
+public class LoginResponse {
+	private final String accessToken;
+	private final String tokenType;
+	private final UserResponse user;
+}

--- a/src/main/java/com/rikuto/revox/dto/user/UserResponse.java
+++ b/src/main/java/com/rikuto/revox/dto/user/UserResponse.java
@@ -1,0 +1,18 @@
+package com.rikuto.revox.dto.user;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+/**
+ * ログイン後に公開するユーザー情報のレスポンスDTOです。
+ */
+@Getter
+@Builder
+public class UserResponse {
+	private final int id;
+	private final String nickname;
+	private final String displayEmail;
+	private final String uniqueUserId;
+	private final LocalDateTime createdAt;
+}

--- a/src/main/java/com/rikuto/revox/dto/user/UserUpdateRequest.java
+++ b/src/main/java/com/rikuto/revox/dto/user/UserUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.rikuto.revox.dto.user;
+
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * ユーザー更新リクエストDTO。
+ * ニックネームのみ更新可能です。
+ */
+@Getter
+@Setter
+@Builder
+public class UserUpdateRequest {
+	@Size(max = 50, message = "ニックネームは50文字以内で入力してください。")
+	private String nickname;
+}

--- a/src/main/java/com/rikuto/revox/exception/AuthenticationException.java
+++ b/src/main/java/com/rikuto/revox/exception/AuthenticationException.java
@@ -1,0 +1,16 @@
+package com.rikuto.revox.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class AuthenticationException extends RuntimeException {
+
+	public AuthenticationException(String message) {
+		super(message);
+	}
+
+	public AuthenticationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/src/main/java/com/rikuto/revox/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/rikuto/revox/exception/GlobalExceptionHandler.java
@@ -23,6 +23,16 @@ public class GlobalExceptionHandler {
 		return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
 	}
 
+	@ExceptionHandler(AuthenticationException.class)
+	public ResponseEntity<String> handleAuthenticationException(AuthenticationException ex) {
+		return new ResponseEntity<>(ex.getMessage(), HttpStatus.UNAUTHORIZED);
+	}
+
+	@ExceptionHandler(UserAlreadyExistsException.class)
+	public ResponseEntity<String> handleUserAlreadyExistsException (UserAlreadyExistsException ex){
+		return new ResponseEntity<>(ex.getMessage(),HttpStatus.CONFLICT);
+	}
+
 	/**
 	 * @Valid によるバリデーションエラー (MethodArgumentNotValidException) を処理します。
 	 * 無効なリクエストボディが送信された場合に HTTP 400 Bad Request を返します。

--- a/src/main/java/com/rikuto/revox/exception/UserAlreadyExistsException.java
+++ b/src/main/java/com/rikuto/revox/exception/UserAlreadyExistsException.java
@@ -1,0 +1,17 @@
+package com.rikuto.revox.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class UserAlreadyExistsException extends RuntimeException {
+
+	public UserAlreadyExistsException(String message) {
+		super(message);
+	}
+
+	public UserAlreadyExistsException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/src/main/java/com/rikuto/revox/mapper/AiQuestionMapper.java
+++ b/src/main/java/com/rikuto/revox/mapper/AiQuestionMapper.java
@@ -1,11 +1,11 @@
 package com.rikuto.revox.mapper;
 
+import com.rikuto.revox.domain.User;
 import com.rikuto.revox.dto.aiquestion.AiQuestionCreateRequest;
 import com.rikuto.revox.dto.aiquestion.AiQuestionResponse;
 import com.rikuto.revox.domain.AiQuestion;
 import com.rikuto.revox.domain.Bike;
 import com.rikuto.revox.domain.Category;
-import com.rikuto.revox.domain.User;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/rikuto/revox/mapper/LoginResponseMapper.java
+++ b/src/main/java/com/rikuto/revox/mapper/LoginResponseMapper.java
@@ -1,0 +1,36 @@
+package com.rikuto.revox.mapper;
+
+import com.rikuto.revox.domain.User;
+import com.rikuto.revox.dto.auth.LoginResponse;
+import com.rikuto.revox.dto.user.UserResponse;
+import org.springframework.stereotype.Component;
+
+/**
+ * 外部認証専用のLoginResponseMapperです。
+ */
+@Component
+public class LoginResponseMapper {
+
+	private final UserResponseMapper userResponseMapper;
+	public LoginResponseMapper(UserResponseMapper userResponseMapper) {
+		this.userResponseMapper = userResponseMapper;
+	}
+
+	/**
+	 * AuthUserドメインをLoginResponseに変換します。
+	 * 認証成功時のユーザー情報をフロントへ渡すためのレスポンスマッパーです。
+	 *
+	 * @param user ユーザー情報
+	 * @param accessToken 外部認証のJWTトークン
+	 * @return 認証成功時のユーザー情報
+	 */
+	public LoginResponse toLoginResponse(User user, String accessToken) {
+		UserResponse userResponse = userResponseMapper.toResponse(user);
+
+		return LoginResponse.builder()
+				.accessToken(accessToken)
+				.tokenType("Bearer")
+				.user(userResponse)
+				.build();
+	}
+}

--- a/src/main/java/com/rikuto/revox/mapper/UserResponseMapper.java
+++ b/src/main/java/com/rikuto/revox/mapper/UserResponseMapper.java
@@ -1,0 +1,29 @@
+package com.rikuto.revox.mapper;
+
+import com.rikuto.revox.domain.User;
+import com.rikuto.revox.dto.user.UserResponse;
+import org.springframework.stereotype.Component;
+
+/**
+ * 外部認証専用のUserMapperです。
+ */
+@Component
+public class UserResponseMapper {
+
+	/**
+	 * AuthUserドメインをUserResponseに変換します。
+	 * 認証後のユーザー情報をフロントへ渡すためのレスポンスマッパーです。
+	 *
+	 * @param user ユーザー情報
+	 * @return 返還後のレスポンスユーザー情報
+	 */
+	public UserResponse toResponse(User user) {
+		return UserResponse.builder()
+				.id(user.getId())
+				.nickname(user.getNickname())
+				.displayEmail(user.getDisplayEmail())
+				.uniqueUserId(user.getUniqueUserId())
+				.createdAt(user.getCreatedAt())
+				.build();
+	}
+}

--- a/src/main/java/com/rikuto/revox/repository/UserRepository.java
+++ b/src/main/java/com/rikuto/revox/repository/UserRepository.java
@@ -7,15 +7,15 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 /**
- * ユーザーに関するリポジトリです。
- * JpaRepositoryを継承しています。
- * 管理者機能として論理削除を考慮しないCRUDに関してはJPAの標準機能を利用します。
+ * 外部認証専用のユーザーリポジトリです。
+ * uniqueUserIdを主キーとして使用します。
  */
 @Repository
 public interface UserRepository extends JpaRepository<User, Integer> {
 
 	/**
-	 * 登録後のユーザーIDでの検索を行います。論理削除された情報は取得しません。
+	 * ユーザーIDでの検索を行います。論理削除された情報は取得しません。
+	 * ログイン後の内部操作で使用します。。
 	 *
 	 * @param id　ユーザーID
 	 * @return ユーザー情報
@@ -23,27 +23,12 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 	Optional<User> findByIdAndIsDeletedFalse(Integer id);
 
 	/**
-	 * メールアドレスでの検索を行います。論理削除された情報は取得しません。
+	 * アプリケーション独自の一意なユーザーIDでの検索を行います。
+	 * 論理削除された情報は取得しません。
+	 * JWTフィルターでの認証に使用します。
 	 *
-	 * @param email メールアドレス
-	 * @return メールアドレスに紐づいたユーザー情報
+	 * @param uniqueUserId アプリケーション独自の一意なユーザーID
+	 * @return アプリケーション独自の一意なユーザーIDに紐づいたユーザー情報
 	 */
-	Optional<User> findByEmailAndIsDeletedFalse(String email);
-
-	/**
-	 * グーグルIDでの検索を行います。論理削除された情報は取得しません。
-	 *
-	 * @param googleId グーグルID
-	 * @return グーグルIDに紐づいたユーザー情報
-	 */
-	Optional<User> findByGoogleIdAndIsDeletedFalse(String googleId);
-
-	/**
-	 * LineIDでの検索を行います。論理削除された情報は取得しません。
-	 *
-	 * @param lineId ラインID
-	 * @return ラインIDに紐づいたユーザー情報
-	 */
-	Optional<User> findByLineIdAndIsDeletedFalse(String lineId);
-
+	Optional<User> findByUniqueUserIdAndIsDeletedFalse(String uniqueUserId);
 }

--- a/src/main/java/com/rikuto/revox/security/SecurityConfig.java
+++ b/src/main/java/com/rikuto/revox/security/SecurityConfig.java
@@ -1,0 +1,68 @@
+package com.rikuto.revox.security;
+
+import com.rikuto.revox.security.details.ExternalAuthUserDetailsService;
+import com.rikuto.revox.security.jwt.JwtAuthenticationFilter;
+import com.rikuto.revox.security.jwt.JwtTokenProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * Security設定に関するBeanを設置したクラスです。
+ * 全てのリクセストはJwtAuthenticationFilterを通過します。
+ */
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
+public class SecurityConfig {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final ExternalAuthUserDetailsService userDetailsService;
+
+	public SecurityConfig(JwtTokenProvider jwtTokenProvider, ExternalAuthUserDetailsService userDetailsService) {
+		this.jwtTokenProvider = jwtTokenProvider;
+		this.userDetailsService = userDetailsService;
+	}
+
+	/**
+	 * JWTおよびユーザー詳細をSpringが認識するようBeanコンテナにするメソッド
+	 *
+	 * @return JWTおよびユーザー詳細
+	 */
+	@Bean
+	public JwtAuthenticationFilter jwtAuthenticationFilter() {
+		return new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService);
+	}
+
+	/**
+	 * セキュリティフィルターチェーンをカスタマイズしてBeanとして登録します。
+	 * JWT認証とステートレスなセッション管理を設定します。
+	 *
+	 * @param http Spring Securityの設定ハブ
+	 * @return カスタマイズされたSecurityFilterChainオブジェクト
+	 * @throws Exception 設定時に発生する可能性のある例外
+	 */
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http
+				.csrf(AbstractHttpConfigurer::disable)
+				.authorizeHttpRequests(authorize -> authorize
+						.requestMatchers("/api/auth/**").permitAll()
+						.anyRequest().authenticated()
+				)
+				.sessionManagement(session -> session
+						.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+				);
+
+		JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService);
+		http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+		return http.build();
+	}
+}

--- a/src/main/java/com/rikuto/revox/security/details/ExternalAuthUserDetails.java
+++ b/src/main/java/com/rikuto/revox/security/details/ExternalAuthUserDetails.java
@@ -1,0 +1,61 @@
+package com.rikuto.revox.security.details;
+
+import com.rikuto.revox.domain.User;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * 外部認証専用のUserDetailsです。
+ * uniqueUserIdを主キーとして使用し、パスワード認証は行いません。
+ * セキュリティ設定（有効期限、ロック機能、非アクティブ）は全てtureのため無効です。
+ */
+@EqualsAndHashCode
+public class ExternalAuthUserDetails implements UserDetails {
+
+	@Getter
+	private final int id;
+	@Getter
+	private final String uniqueUserId;
+	private final Collection<? extends GrantedAuthority> authorities;
+
+	/**
+	 * AuthUserドメインからUserDetailsを作成するコンストラクタです。
+	 *
+	 * @param user 認証済みユーザーのドメインオブジェクト
+	 */
+	public ExternalAuthUserDetails(User user) {
+
+		this.id = user.getId();
+		this.uniqueUserId = user.getUniqueUserId();
+
+		// カンマ区切りでロールを分け、文字列として役割を取得します。
+		this.authorities = user.getRoles() != null ?
+				Arrays.stream(user.getRoles().split(","))
+						.map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+						.toList() :
+				Collections.emptyList();
+	}
+
+
+	@Override
+	public String getUsername() {
+		return uniqueUserId; // 外部認証ではuniqueUserIdが識別子
+	}
+
+	@Override
+	public String getPassword() {
+		return null; // 外部認証のためパスワードは不要
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return authorities;
+	}
+}

--- a/src/main/java/com/rikuto/revox/security/details/ExternalAuthUserDetailsService.java
+++ b/src/main/java/com/rikuto/revox/security/details/ExternalAuthUserDetailsService.java
@@ -1,0 +1,35 @@
+package com.rikuto.revox.security.details;
+
+import com.rikuto.revox.domain.User;
+import com.rikuto.revox.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+/**
+ * 外部認証専用のUserDetailsServiceです。
+ * uniqueUserIdを使用してユーザー情報を取得します。
+ */
+@Service
+public class ExternalAuthUserDetailsService {
+
+	private final UserRepository userRepository;
+
+	public ExternalAuthUserDetailsService(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+
+	/**
+	 * uniqueUserIdでユーザー情報を検索し、UserDetailsを返します。
+	 *
+	 * @param uniqueUserId 外部認証システムの一意なユーザーID
+	 * @return UserDetails実装オブジェクト
+	 * @throws UsernameNotFoundException ユーザーが見つからない場合
+	 */
+	public UserDetails loadUserByUniqueUserId(String uniqueUserId) throws UsernameNotFoundException {
+		User uniqueUser = userRepository.findByUniqueUserIdAndIsDeletedFalse(uniqueUserId)
+				.orElseThrow(() -> new UsernameNotFoundException("ユーザーが見つかりません: " + uniqueUserId));
+
+		return new ExternalAuthUserDetails(uniqueUser);
+	}
+}

--- a/src/main/java/com/rikuto/revox/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/rikuto/revox/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,87 @@
+package com.rikuto.revox.security.jwt;
+
+import com.rikuto.revox.security.details.ExternalAuthUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * JWT認証フィルターです。
+ * JWTトークンからuniqueUserIdを抽出し、認証情報を設定します。
+ */
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final ExternalAuthUserDetailsService userDetailsService;
+
+	public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider,
+	                               ExternalAuthUserDetailsService userDetailsService) {
+		this.jwtTokenProvider = jwtTokenProvider;
+		this.userDetailsService = userDetailsService;
+	}
+
+	/**
+	 * 各HTTPリクエストに対して一度だけ実行されるフィルター処理です。
+	 * このメソッドは、以下のステップでJWT認証を行います。
+	 * 1. リクエストヘッダーからJWTトークンを抽出し、その有効性を検証します。
+	 * 2. 有効なトークンからユーザー情報を取得し、認証オブジェクトを生成します。
+	 * 3. 認証オブジェクトをSecurityContextに設定し、後続の処理でユーザーが認証済みと認識されるようにします。
+	 * トークンが無効な場合や存在しない場合は、認証は行われず、次のフィルターへ処理が渡されます。
+	 *
+	 * @param request HTTPリクエスト
+	 * @param response HTTPレスポンス
+	 * @param filterChain フィルターチェーン
+	 * @throws ServletException Servlet例外
+	 * @throws IOException 入出力例外
+	 */
+	@Override
+	protected void doFilterInternal(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response,
+	                                @NotNull FilterChain filterChain) throws ServletException, IOException {
+		try {
+			String jwt = getJwtFromRequest(request);
+
+			if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
+
+				String uniqueUserId = jwtTokenProvider.getUniqueUserIdFromToken(jwt);
+				UserDetails userDetails = userDetailsService.loadUserByUniqueUserId(uniqueUserId);
+
+				UsernamePasswordAuthenticationToken authentication =
+						new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+				authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			}
+		} catch (Exception ex) {
+			logger.error("セキュリティコンテキストにユーザー認証を設定できませんでした", ex);
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	/**
+	 * リクエストヘッダーからJWTトークンを抽出します。
+	 *
+	 * @param request HTTPリクエスト
+	 * @return JWTトークン文字列（Bearerプレフィックスを除く）
+	 */
+	private String getJwtFromRequest(HttpServletRequest request) {
+
+		String bearerToken = request.getHeader("Authorization");
+
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+
+			return bearerToken.substring(7);
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/rikuto/revox/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/rikuto/revox/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,81 @@
+package com.rikuto.revox.security.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+/**
+ * JWTトークンの生成と検証を行うクラスです。
+ */
+@Component
+public class JwtTokenProvider {
+
+	private final SecretKey secretKey;
+	private final Long validityInMilliseconds;
+
+	/**
+	 * 秘密キーおよび有効期限に関するコンストラクタです。
+	 * 秘密キーはHS256アルゴリズムに適合するバイト型に変換されます。
+	 *
+	 * @param secretKey 秘密キー
+	 * @param validityInMilliseconds 有効期限
+	 */
+	public JwtTokenProvider(@Value("${JWT_SECRET_KEY}") String secretKey,
+	                        @Value("${JWT_EXPIRATION}") Long validityInMilliseconds) {
+
+		this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes());
+		this.validityInMilliseconds = validityInMilliseconds;
+	}
+
+	/**
+	 * 認証成功時にJWTトークンの生成を行います。
+	 * @param uniqueUserId ユーザーの一意なID
+	 * @return 生成されたJWT文字列
+	 */
+	public String generateToken(String uniqueUserId){
+		Date now = new Date();
+		Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+		return Jwts.builder()
+				.setSubject(uniqueUserId)
+				.setIssuedAt(now)
+				.setExpiration(validity)
+				.signWith(secretKey, SignatureAlgorithm.HS256)
+				.compact();
+	}
+
+	/**
+	 * 生成後のJWTトークンからIDの抽出を行います。
+	 * @param token 生成済みのJWTトークン
+	 * @return ユーザーの一意なID
+	 */
+	public String getUniqueUserIdFromToken(String token){
+		return Jwts.parserBuilder()
+				.setSigningKey(secretKey)
+				.build()
+
+				.parseClaimsJws(token)
+				.getBody()
+				.getSubject();
+	}
+
+	/**
+	 * 受け取ったトークンが有効か検証します。
+	 * @param token 生成済みのJWTトークン
+	 * @return トークンの有効判定
+	 */
+	public boolean validateToken(String token){
+		try {
+			Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+
+			return true;
+		}catch(Exception e){
+			return false;
+		}
+	}
+}

--- a/src/main/java/com/rikuto/revox/service/AiQuestionService.java
+++ b/src/main/java/com/rikuto/revox/service/AiQuestionService.java
@@ -13,7 +13,6 @@ import com.rikuto.revox.repository.AiQuestionRepository;
 import com.rikuto.revox.repository.BikeRepository;
 import com.rikuto.revox.repository.CategoryRepository;
 import com.rikuto.revox.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/rikuto/revox/service/AuthService.java
+++ b/src/main/java/com/rikuto/revox/service/AuthService.java
@@ -1,0 +1,96 @@
+package com.rikuto.revox.service;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.rikuto.revox.domain.User;
+import com.rikuto.revox.dto.auth.GoogleTokenPayload;
+import com.rikuto.revox.dto.auth.LoginResponse;
+import com.rikuto.revox.exception.AuthenticationException;
+import com.rikuto.revox.mapper.LoginResponseMapper;
+import com.rikuto.revox.security.jwt.JwtTokenProvider;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+
+/**
+ * 外部認証専用の認証サービスです。
+ * 認証およびJWTトークンの生成を行います。
+ */
+@Service
+public class AuthService {
+
+	private final UserService userService;
+	private final LoginResponseMapper loginResponseMapper;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final String googleClientId;
+
+	public AuthService(UserService userService, LoginResponseMapper loginResponseMapper,
+	                   JwtTokenProvider jwtTokenProvider, @Value("${google.client-id}") String googleClientId) {
+		this.userService = userService;
+		this.loginResponseMapper = loginResponseMapper;
+		this.jwtTokenProvider = jwtTokenProvider;
+		this.googleClientId = googleClientId;
+	}
+
+	/**
+	 * Google認証でのログイン処理を行います。
+	 * 検索後ユーザー情報がない場合登録を行います。
+	 *
+	 * @param googleIdToken Google IDトークン
+	 * @return ログインレスポンス（JWTトークンとユーザー情報）
+	 */
+	public LoginResponse loginWithGoogle(String googleIdToken) {
+		GoogleTokenPayload idToken = verifyGoogleIdToken(googleIdToken);
+		if(idToken.getEmail() == null) {
+			throw new AuthenticationException("Googleアカウントのメールアドレスが取得できません。");
+		}
+		User user = userService.findOrCreateUser(
+				idToken.getSub(),
+				idToken.getName(),
+				idToken.getEmail()
+		);
+
+		String token = jwtTokenProvider.generateToken(user.getUniqueUserId());
+
+		return loginResponseMapper.toLoginResponse(user, token);
+	}
+
+	/**
+	 * Google IDトークンを検証し、ペイロードを抽出するヘルパーメソッドです。
+	 *
+	 * @param idTokenString Googleから受け取ったIDトークン文字列
+	 * @return ペイロード情報を含むDTO
+	 * @throws AuthenticationException トークンが無効な場合にスロー
+	 */
+	private GoogleTokenPayload verifyGoogleIdToken(String idTokenString) {
+		GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), new GsonFactory())
+				.setAudience(Collections.singletonList(googleClientId))
+				.build();
+		try {
+			GoogleIdToken idToken = verifier.verify(idTokenString);
+			if(idToken != null) {
+				GoogleIdToken.Payload payload = idToken.getPayload();
+
+				return GoogleTokenPayload.builder()
+						.sub(payload.getSubject())
+						.email(payload.getEmail())
+						.name((String) payload.get("name"))
+						.build();
+			} else {
+				// ここでトークンが無効な理由が分からないことが多いのでログ出力する
+				System.err.println("Google IDトークンの検証に失敗しました。トークン: " + idTokenString);
+				throw new AuthenticationException("無効なGoogle IDトークンです。");
+			}
+		} catch (GeneralSecurityException | IOException e) {
+			System.err.println("Google IDトークンの検証時に例外発生。トークン: " + idTokenString);
+			e.printStackTrace();
+			throw new AuthenticationException("Google IDトークンの検証に失敗しました。", e);
+		}
+	}
+}

--- a/src/main/java/com/rikuto/revox/service/BikeService.java
+++ b/src/main/java/com/rikuto/revox/service/BikeService.java
@@ -1,10 +1,10 @@
 package com.rikuto.revox.service;
 
+import com.rikuto.revox.domain.User;
 import com.rikuto.revox.mapper.BikeMapper;
 import com.rikuto.revox.dto.bike.BikeCreateRequest;
 import com.rikuto.revox.dto.bike.BikeResponse;
 import com.rikuto.revox.domain.Bike;
-import com.rikuto.revox.domain.User;
 import com.rikuto.revox.exception.ResourceNotFoundException;
 import com.rikuto.revox.repository.BikeRepository;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/rikuto/revox/service/UserService.java
+++ b/src/main/java/com/rikuto/revox/service/UserService.java
@@ -1,21 +1,99 @@
 package com.rikuto.revox.service;
 
 import com.rikuto.revox.domain.User;
+import com.rikuto.revox.dto.user.UserResponse;
+import com.rikuto.revox.dto.user.UserUpdateRequest;
 import com.rikuto.revox.exception.ResourceNotFoundException;
+import com.rikuto.revox.mapper.UserResponseMapper;
 import com.rikuto.revox.repository.UserRepository;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 外部認証専用のユーザーサービスクラスです。
+ * CRUDおよび認可を行います。
+ */
 @Service
 public class UserService {
-	private final UserRepository userRepository;
 
-	public UserService(UserRepository userRepository) {
+	private final UserRepository userRepository;
+	private final UserResponseMapper userResponseMapper;
+
+	public UserService(UserRepository userRepository, UserResponseMapper userResponseMapper) {
 		this.userRepository = userRepository;
+		this.userResponseMapper = userResponseMapper;
 	}
 
-	// IDで直接取得
+	/**
+	 * ユーザーIDでユーザー情報を検索し、フロント側でユーザー情報を取得します。
+	 * 本人または管理者のみアクセス可能です。
+	 *
+	 * @param userId 一意のユーザーID
+	 * @return ユーザー情報
+	 */
+	@PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
 	public User findById(Integer userId) {
 		return userRepository.findByIdAndIsDeletedFalse(userId)
 				.orElseThrow(() -> new ResourceNotFoundException("ユーザーが見つかりません"));
+	}
+
+	/**
+	 * ユーザー情報の更新を行います。
+	 * 本人および管理者のみアクセス可能です。
+	 * 外部認証のためニックネームのみ更新可能です。
+	 *
+	 * @param updateRequest 更新リクエスト
+	 * @param userId 一意のユーザーID
+	 * @return 更新後のユーザーレスポンス
+	 */
+	@PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
+	@Transactional
+	public UserResponse updateUser(UserUpdateRequest updateRequest, Integer userId) {
+		User updateUser = userRepository.findByIdAndIsDeletedFalse(userId)
+				.orElseThrow(() -> new ResourceNotFoundException("ユーザーが見つかりません"));
+
+		updateUser.updateFrom(updateRequest);
+		User savedUser = userRepository.save(updateUser);
+
+		return userResponseMapper.toResponse(savedUser);
+	}
+
+	/**
+	 * ユーザー情報を論理削除します。
+	 * 本人および管理者のみアクセス可能です。
+	 *
+	 * @param userId 一意のユーザーID
+	 */
+	@PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
+	@Transactional
+	public void softDeleteUser(Integer userId) {
+		User deleteUser = userRepository.findByIdAndIsDeletedFalse(userId)
+				.orElseThrow(() -> new ResourceNotFoundException("ユーザーが見つかりません"));
+
+		deleteUser.softDelete();
+
+		userRepository.save(deleteUser);
+	}
+
+	/**
+	 * 外部認証でのユーザー検索または新規登録を行います。
+	 *
+	 * @param uniqueUserId 外部認証での各一意のID（Googleのsubクレームなど）
+	 * @param name 外部認証先のユーザーネーム
+	 * @param email 外部認証に使用されているメールアドレス
+	 * @return ユーザー情報
+	 */
+	@Transactional
+	public User findOrCreateUser(String uniqueUserId, String name, String email) {
+		return userRepository.findByUniqueUserIdAndIsDeletedFalse(uniqueUserId)
+				.orElseGet(() -> {
+					User newUser = User.builder()
+							.uniqueUserId(uniqueUserId)
+							.nickname(name)
+							.displayEmail(email)
+							.build();
+					return userRepository.save(newUser);
+				});
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,23 +1,17 @@
-# application.yml (単一ファイルでの管理)
-
-# 共通のログ設定
 logging:
   level:
     root: INFO
     org:
-      springframework:
+      springframework: INFO
       hibernate:
-        SQL: DEBUG      # 本番では通常 INFO にする
+        SQL: DEBUG
         type:
           descriptor:
             sql:
-              BasicBinder: TRACE # 本番では通常 INFO にする
+              BasicBinder: TRACE
 
-# メインとなるデータベース設定
 spring:
   datasource:
-    # ローカル開発ではDocker Composeのサービス名 'db' (または 'localhost:3308') を指定し、
-    # 本番環境ではデプロイ時に本番DBのホスト名/ポートを環境変数等で上書きする想定
     url: jdbc:mysql://localhost:3308/${MYSQL_DATABASE}?useSSL=false&serverTimezone=Asia/Tokyo&allowPublicKeyRetrieval=true&useUnicode=true&characterEncoding=utf8
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
@@ -26,8 +20,8 @@ spring:
   jpa:
     database: MYSQL
     hibernate:
-      ddl-auto: none  # Flywayでスキーマ管理するため、JPAの自動生成は無効
-    show-sql: true    # 本番では通常 false にするべきだが、単一ファイルのため統一
+      ddl-auto: none
+    show-sql: true
     properties:
       hibernate:
         format_sql: true
@@ -36,14 +30,22 @@ spring:
     enabled: true
     locations: classpath:db/migration
 
-    mvc:
-      cors:
-        allowed-origins: "http://localhost:3000"
-        allowed-methods: "GET,POST,PUT,DELETE,OPTIONS"
-        allowed-headers: "*"
+mvc:
+  cors:
+    allowed-origins: "http://localhost:3000"
+    allowed-methods: "GET,POST,PUT,DELETE,OPTIONS"
+    allowed-headers: "*"
 
-    gemini:
-      model: "gemini-2.5-flash"
-      project-id: ${GOOGLE_CLOUD_PROJECT}
-      location: ${GOOGLE_CLOUD_LOCATION:us-central1}
-      system-instruction: "あなたはバイクの専門家です..."
+gemini:
+  api-key: ${GEMINI_API_KEY}
+  model: "gemini-2.5-flash"
+  project-id: ${GOOGLE_CLOUD_PROJECT}
+  location: ${GOOGLE_CLOUD_LOCATION:us-central1}
+  system-instruction: "あなたはバイクの専門家です..."
+
+google:
+  client-id: ${GOOGLE_CLIENT_ID}
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY}
+  expiration: ${JWT_EXPIRATION}

--- a/src/main/resources/db/migration/V001__Create_users_table.sql
+++ b/src/main/resources/db/migration/V001__Create_users_table.sql
@@ -1,17 +1,13 @@
 CREATE TABLE users (
     id INT AUTO_INCREMENT PRIMARY KEY COMMENT 'ユーザーID（主キー）',
     nickname VARCHAR(50) NOT NULL COMMENT 'ユーザーのニックネーム',
-    email VARCHAR(255) COMMENT 'メールアドレス',
-    google_id VARCHAR(100) COMMENT 'Google認証ID（OAuth用）',
-    line_id VARCHAR(100) COMMENT 'LINE認証ID（OAuth用）',
+    display_email VARCHAR(255) COMMENT '外部認証から取得したメールアドレス（表示用のみ）',
+    unique_user_id VARCHAR(255) NOT NULL UNIQUE COMMENT '外部認証システムから取得した一意なユーザーID',
+    roles VARCHAR(100) NOT NULL DEFAULT 'USER' COMMENT 'ユーザーの権限情報',
     is_deleted BOOLEAN NOT NULL DEFAULT FALSE COMMENT '論理削除フラグ',
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時',
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
-
-    CONSTRAINT uk_users_google_id UNIQUE (google_id),
-    CONSTRAINT uk_users_line_id UNIQUE (line_id)
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時'
 );
 
-CREATE INDEX idx_users_google_id ON users(google_id);
-CREATE INDEX idx_users_line_id ON users(line_id);
+CREATE INDEX idx_users_unique_user_id ON users(unique_user_id);
 CREATE INDEX idx_users_is_deleted ON users(is_deleted);

--- a/src/test/java/com/rikuto/revox/controller/AuthUserControllerTest.java
+++ b/src/test/java/com/rikuto/revox/controller/AuthUserControllerTest.java
@@ -1,0 +1,108 @@
+package com.rikuto.revox.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rikuto.revox.dto.auth.LoginRequest;
+import com.rikuto.revox.dto.auth.LoginResponse;
+import com.rikuto.revox.dto.user.UserResponse;
+import com.rikuto.revox.service.AuthService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+		controllers = AuthUserController.class,
+		excludeAutoConfiguration = {
+				SecurityAutoConfiguration.class,
+				UserDetailsServiceAutoConfiguration.class
+		}
+)
+@Import(AuthUserControllerTest.AuthUserControllerTestConfig.class)
+class AuthUserControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private AuthService authService;
+
+	private LoginRequest LoginRequest;
+	private LoginResponse loginResponse;
+
+	private final String dummyAccessToken = "dummyAccessToken";
+
+	@BeforeEach
+	void setup() {
+		String dummyIdToken = "dummyIdToken";
+		LoginRequest = new LoginRequest(dummyIdToken);
+
+		loginResponse = LoginResponse.builder()
+				.accessToken(dummyAccessToken)
+				.tokenType("Bearer")
+				.user(UserResponse.builder()
+						.id(999999)
+						.nickname("testUser")
+						.uniqueUserId("unique_user_id")
+						.displayEmail("test@example.com")
+						.createdAt(LocalDateTime.now())
+						.build())
+				.build();
+		reset(authService);
+	}
+
+
+	@Test
+	public void Googleの外部認証で正常にログインできること()throws Exception{
+		when(authService.loginWithGoogle(LoginRequest.idToken())).thenReturn(loginResponse);
+
+		mockMvc.perform(post("/api/auth/google")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(LoginRequest)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.accessToken").value(dummyAccessToken))
+				.andExpect(jsonPath("$.tokenType").value("Bearer"))
+				.andExpect(jsonPath("$.user.id").value(999999))
+				.andExpect(jsonPath("$.user.nickname").value("testuser"))
+				.andExpect(jsonPath("$.user.displayEmail").value("test@example.com"));
+	}
+
+	@Test
+	void 不正なリクエストの場合400_Bad_Requestを返すこと() throws Exception {
+		LoginRequest invalidRequest = new LoginRequest("");
+
+		mockMvc.perform(post("/api/auth/google")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(invalidRequest)))
+				.andExpect(status().isBadRequest());
+
+		Mockito.verify(authService, Mockito.never()).loginWithGoogle(Mockito.anyString());
+	}
+
+	@TestConfiguration
+	static class AuthUserControllerTestConfig {
+		@Bean
+		public AuthService authService() {
+			return Mockito.mock(AuthService.class);
+		}
+	}
+}

--- a/src/test/java/com/rikuto/revox/repository/AiQuestionRepositoryTest.java
+++ b/src/test/java/com/rikuto/revox/repository/AiQuestionRepositoryTest.java
@@ -1,9 +1,9 @@
 package com.rikuto.revox.repository;
 
 import com.rikuto.revox.domain.AiQuestion;
+import com.rikuto.revox.domain.User;
 import com.rikuto.revox.domain.Bike;
 import com.rikuto.revox.domain.Category;
-import com.rikuto.revox.domain.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -29,10 +29,9 @@ class AiQuestionRepositoryTest {
 	@Autowired
 	private AiQuestionRepository aiQuestionRepository;
 
-	private User createUser(String nickname, String email) {
+	private User createUser(String nickname) {
 		return userRepository.save(User.builder()
 				.nickname(nickname)
-				.email(email)
 				.build());
 	}
 
@@ -64,7 +63,7 @@ class AiQuestionRepositoryTest {
 
 	@Test
 	void ユーザーIDに紐づくAI質問履歴を正しく取得できること() {
-		User user = createUser("TestUser", "test@example.com");
+		User user = createUser("TestUser");
 		Bike bike = createBike(user, "Honda", "CBR250RR");
 		Category category = createCategory("TestCategory", 999);
 
@@ -81,12 +80,12 @@ class AiQuestionRepositoryTest {
 
 	@Test
 	void 別ユーザーのAI質問履歴は検索結果に含まれないこと() {
-		User owner = createUser("User1", "owner@example.com");
+		User owner = createUser("User1");
 		Bike ownersBike = createBike(owner, "Honda", "CBR250RR");
 		Category category = createCategory("TestCategory", 999);
 		AiQuestion ownersQuestion = createAiQuestion(owner, ownersBike, category, "オーナーの質問", "オーナーの回答", false);
 
-		User anotherUser = createUser("User2", "another@example.com");
+		User anotherUser = createUser("User2");
 		Bike anotherbike = createBike(anotherUser, "Yamaha", "YZF-R1");
 		createAiQuestion(anotherUser, anotherbike, category, "別ユーザーの質問", "別ユーザーの回答", false);
 
@@ -107,7 +106,7 @@ class AiQuestionRepositoryTest {
 	@Test
 	void AI質問履歴がないユーザーには空のリストを返すこと(){
 
-		User owner = createUser("EmptyUser", "empty@example.com");
+		User owner = createUser("EmptyUser");
 
 		List<AiQuestion> aiQuestions = aiQuestionRepository.findByUserIdAndIsDeletedFalse(owner.getId());
 
@@ -117,7 +116,7 @@ class AiQuestionRepositoryTest {
 	@Test
 	void 論理削除されたAI質問は検索結果に含まれないこと(){
 
-		User user = createUser("User", "user@example.com");
+		User user = createUser("User");
 		Bike bike = createBike(user, "Honda", "CBR250RR");
 		Category category = createCategory("TestCategory", 999);
 
@@ -133,7 +132,7 @@ class AiQuestionRepositoryTest {
 	@Test
 	void 複数のバイクとカテゴリーに関するAI質問履歴を正しく取得できること(){
 
-		User user = createUser("MultiUser", "multi@example.com");
+		User user = createUser("MultiUser");
 
 		Bike bike1 = createBike(user, "Honda", "CBR250RR");
 		Bike bike2 = createBike(user, "Yamaha", "YZF-R1");

--- a/src/test/java/com/rikuto/revox/repository/BikeRepositoryTest.java
+++ b/src/test/java/com/rikuto/revox/repository/BikeRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.rikuto.revox.repository;
 
-import com.rikuto.revox.domain.Bike;
 import com.rikuto.revox.domain.User;
+import com.rikuto.revox.domain.Bike;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -24,10 +24,9 @@ class BikeRepositoryTest {
 	@Autowired
 	private BikeRepository bikeRepository;
 
-	private User createUser(String nickname, String email) {
+	private User createUser(String nickname) {
 		return userRepository.save(User.builder()
 				.nickname(nickname)
-				.email(email)
 				.build());
 	}
 
@@ -45,7 +44,7 @@ class BikeRepositoryTest {
 	@Test
 	void ユーザーIDに紐づくバイク情報を正しく取得できること() {
 
-		User user = createUser("TestUser", "test@example.com");
+		User user = createUser("TestUser");
 
 		createBike(user, "TestMfr", "Z1", "TST-001", 2023, false);
 		createBike(user, "TestTestMfr", "Z2", "TST-002", 2024, false);
@@ -61,10 +60,10 @@ class BikeRepositoryTest {
 	@Test
 	void 別ユーザーのバイクは検索結果に含まれないこと() {
 
-		User owner = createUser("User1", "owner@example.com");
+		User owner = createUser("User1");
 		Bike ownersBike = createBike(owner, "TestMfr", "Z1", "TST-001", 2023, false);
 
-		User anotherUser = createUser("User2", "anotherUser@example.com");
+		User anotherUser = createUser("User2");
 		createBike(anotherUser, "TestTestMfr", "Z2", "TST-002", 2024, false);
 
 		List<Bike> bikes = bikeRepository.findByUserIdAndIsDeletedFalse(owner.getId());
@@ -84,7 +83,7 @@ class BikeRepositoryTest {
 	@Test
 	void バイク未登録ユーザーには空のリストを返すこと() {
 
-		User user = createUser("EmptyUser", "empty@example.com");
+		User user = createUser("EmptyUser");
 
 		List<Bike> bikes = bikeRepository.findByUserIdAndIsDeletedFalse(user.getId());
 
@@ -94,7 +93,7 @@ class BikeRepositoryTest {
 	@Test
 	void 論理削除されたバイクは検索結果に含まれないこと() {
 
-		User user = createUser("User", "user@example.com");
+		User user = createUser("User");
 
 		createBike(user, "TestMfr", "Z1", "TST-001", 2023, false);
 		createBike(user, "TestTestMfr", "Z2", "TST-002", 2024, true);
@@ -108,7 +107,7 @@ class BikeRepositoryTest {
 	@Test
 	void findByIdAndUserIdでバイクを正しく取得できること() {
 
-		User user = createUser("FindUser", "find@example.com");
+		User user = createUser("FindUser");
 		Bike bike = createBike(user, "TestMfr", "Z1", "TST-001", 2023, false);
 
 		Optional<Bike> found = bikeRepository.findByIdAndUserIdAndIsDeletedFalse(user.getId(), bike.getId());
@@ -120,7 +119,7 @@ class BikeRepositoryTest {
 	@Test
 	void findByIdAndUserIdで論理削除されたバイクは取得できないこと() {
 
-		User user = createUser("DeletedFindUser", "deleted.find@example.com");
+		User user = createUser("DeletedFindUser");
 		Bike deletedBike = createBike(user, "TestMfr", "Z1", "TST-001", 2023, true);
 
 		Optional<Bike> found = bikeRepository.findByIdAndUserIdAndIsDeletedFalse(deletedBike.getId(), user.getId());
@@ -131,10 +130,10 @@ class BikeRepositoryTest {
 	@Test
 	void findByIdAndUserIdで他ユーザーのバイクは取得できないこと() {
 
-		User owner = createUser("User1", "owner@example.com");
+		User owner = createUser("User1");
 		Bike ownersBike = createBike(owner, "TestMfr", "Z1", "TST-001", 2023, false);
 
-		User anotherUser = createUser("User2", "anotherUser@example.com");
+		User anotherUser = createUser("User2");
 
 		Optional<Bike> found = bikeRepository.findByIdAndUserIdAndIsDeletedFalse(ownersBike.getId(), anotherUser.getId());
 

--- a/src/test/java/com/rikuto/revox/service/AiQuestionServiceTest.java
+++ b/src/test/java/com/rikuto/revox/service/AiQuestionServiceTest.java
@@ -66,7 +66,7 @@ class AiQuestionServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		testUser = User.builder().id(1).nickname("testuser").email("test@example.com").build();
+		testUser = User.builder().id(1).nickname("testuser").build();
 		testBike = Bike.builder().id(101).user(testUser).manufacturer("Honda").modelName("CBR250RR").build();
 		testCategory = Category.builder().id(1).name("エンジン").displayOrder(1).build();
 		testAiQuestion = AiQuestion.builder()

--- a/src/test/java/com/rikuto/revox/service/AuthServiceTest.java
+++ b/src/test/java/com/rikuto/revox/service/AuthServiceTest.java
@@ -1,0 +1,85 @@
+package com.rikuto.revox.service;
+
+import com.rikuto.revox.domain.User;
+import com.rikuto.revox.dto.auth.LoginResponse;
+import com.rikuto.revox.dto.user.UserResponse;
+import com.rikuto.revox.exception.AuthenticationException;
+import com.rikuto.revox.mapper.UserResponseMapper;
+import com.rikuto.revox.security.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+	@Mock
+	private UserService userService;
+
+	@Mock
+	private UserResponseMapper userResponseMapper;
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+
+	@InjectMocks
+	private AuthService authService;
+
+	private User testUser;
+	private UserResponse userResponse;
+
+	private final String dummyIdToken = "dummy_google_id_token";
+	private final String dummyAccessToken = "dummy_access_token";
+
+	@BeforeEach
+	void setUp() {
+		testUser = User.builder()
+				.id(1)
+				.uniqueUserId("google-sub-id")
+				.nickname("Test User")
+				.displayEmail("test@google.com")
+				.build();
+
+		userResponse = UserResponse.builder()
+				.id(1)
+				.nickname("Test User")
+				.displayEmail("test@google.com")
+				.build();
+	}
+
+	@Test
+	void Googleの外部認証で正常にログインできること() {
+		when(userService.findOrCreateUser(any(), any(), any())).thenReturn(testUser);
+		when(jwtTokenProvider.generateToken(testUser.getUniqueUserId())).thenReturn(dummyAccessToken);
+		when(userResponseMapper.toResponse(testUser)).thenReturn(userResponse);
+
+		LoginResponse result = authService.loginWithGoogle(dummyIdToken);
+
+		assertThat(result.getAccessToken()).isEqualTo(dummyAccessToken);
+		assertThat(result.getTokenType()).isEqualTo("Bearer");
+		assertThat(result.getUser()).isEqualTo(userResponse);
+		verify(userService).findOrCreateUser(any(), any(), any());
+		verify(jwtTokenProvider).generateToken(testUser.getUniqueUserId());
+		verify(userResponseMapper).toResponse(testUser);
+	}
+
+	@Test
+	void 無効なIDトークンでログインした場合AuthenticationExceptionをスロー() {
+		assertThatThrownBy(() -> authService.loginWithGoogle(dummyIdToken))
+				.isInstanceOf(AuthenticationException.class);
+
+		verify(userService, never()).findOrCreateUser(any(), any(), any());
+		verify(jwtTokenProvider, never()).generateToken(any());
+		verify(userResponseMapper, never()).toResponse(any());
+	}
+}

--- a/src/test/java/com/rikuto/revox/service/BikeServiceTest.java
+++ b/src/test/java/com/rikuto/revox/service/BikeServiceTest.java
@@ -1,7 +1,7 @@
 package com.rikuto.revox.service;
 
-import com.rikuto.revox.domain.Bike;
 import com.rikuto.revox.domain.User;
+import com.rikuto.revox.domain.Bike;
 import com.rikuto.revox.dto.bike.BikeCreateRequest;
 import com.rikuto.revox.dto.bike.BikeResponse;
 import com.rikuto.revox.exception.ResourceNotFoundException;
@@ -48,7 +48,7 @@ class BikeServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		testUser = User.builder().id(1).nickname("testuser").email("test@example.com").build();
+		testUser = User.builder().id(1).nickname("testuser").build();
 		testBike = Bike.builder().id(101).user(testUser).manufacturer("Honda").modelName("CBR250RR").build();
 
 		commonBikeCreateRequest = BikeCreateRequest.builder()

--- a/src/test/java/com/rikuto/revox/service/UserServiceTest.java
+++ b/src/test/java/com/rikuto/revox/service/UserServiceTest.java
@@ -1,0 +1,157 @@
+package com.rikuto.revox.service;
+
+import com.rikuto.revox.domain.User;
+import com.rikuto.revox.dto.user.UserResponse;
+import com.rikuto.revox.dto.user.UserUpdateRequest;
+import com.rikuto.revox.exception.ResourceNotFoundException;
+import com.rikuto.revox.mapper.UserResponseMapper;
+import com.rikuto.revox.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private UserResponseMapper userResponseMapper;
+
+	@InjectMocks
+	private UserService userService;
+
+	private User testUser;
+	private UserUpdateRequest updateRequest;
+	private UserResponse userResponse;
+
+	@BeforeEach
+	void setUp() {
+		testUser = User.builder()
+				.uniqueUserId("test-unique-id")
+				.nickname("テストユーザー")
+				.displayEmail("test@example.com")
+				.isDeleted(false)
+				.build();
+
+		updateRequest = UserUpdateRequest.builder()
+				.nickname("更新後ニックネーム")
+				.build();
+
+		userResponse = UserResponse.builder()
+				.id(1)
+				.nickname("更新後ニックネーム")
+				.displayEmail("test@example.com")
+				.build();
+	}
+
+	@Test
+	void ユーザーIDが存在する場合ユーザーを返す() {
+		Integer userId = 1;
+		when(userRepository.findByIdAndIsDeletedFalse(userId)).thenReturn(Optional.of(testUser));
+
+		User result = userService.findById(userId);
+
+		assertThat(result).isEqualTo(testUser);
+		verify(userRepository).findByIdAndIsDeletedFalse(userId);
+	}
+
+	@Test
+	void ユーザーが存在しない場合ResourceNotFoundExceptionをスロー() {
+		Integer userId = 999;
+		when(userRepository.findByIdAndIsDeletedFalse(userId)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> userService.findById(userId))
+				.isInstanceOf(ResourceNotFoundException.class)
+				.hasMessage("ユーザーが見つかりません");
+		verify(userRepository).findByIdAndIsDeletedFalse(userId);
+	}
+
+	@Test
+	void 正常にユーザー情報を更新() {
+		Integer userId = 1;
+		User updatedUser = User.builder()
+				.uniqueUserId("test-unique-id")
+				.nickname("更新後ニックネーム")
+				.displayEmail("test@example.com")
+				.isDeleted(false)
+				.build();
+
+		when(userRepository.findByIdAndIsDeletedFalse(userId)).thenReturn(Optional.of(testUser));
+		when(userRepository.save(testUser)).thenReturn(updatedUser);
+		when(userResponseMapper.toResponse(updatedUser)).thenReturn(userResponse);
+
+		UserResponse result = userService.updateUser(updateRequest, userId);
+
+		assertThat(result).isEqualTo(userResponse);
+		verify(userRepository).findByIdAndIsDeletedFalse(userId);
+		verify(testUser).updateFrom(updateRequest);
+		verify(userRepository).save(testUser);
+		verify(userResponseMapper).toResponse(updatedUser);
+	}
+
+	@Test
+	void 正常にユーザーを論理削除() {
+		Integer userId = 1;
+		when(userRepository.findByIdAndIsDeletedFalse(userId)).thenReturn(Optional.of(testUser));
+
+		userService.softDeleteUser(userId);
+
+		verify(userRepository).findByIdAndIsDeletedFalse(userId);
+		verify(testUser).softDelete();
+		verify(userRepository).save(testUser);
+	}
+
+	@Test
+	void 既存ユーザーが存在する場合既存ユーザーを返す() {
+		String uniqueUserId = "existing-unique-id";
+		String name = "既存ユーザー";
+		String email = "existing@example.com";
+
+		when(userRepository.findByUniqueUserIdAndIsDeletedFalse(uniqueUserId))
+				.thenReturn(Optional.of(testUser));
+
+		User result = userService.findOrCreateUser(uniqueUserId, name, email);
+
+		assertThat(result).isEqualTo(testUser);
+		verify(userRepository).findByUniqueUserIdAndIsDeletedFalse(uniqueUserId);
+		verify(userRepository, never()).save(any());
+	}
+
+	@Test
+	void  新規ユーザーの場合新しいユーザーを作成して返す() {
+		String uniqueUserId = "new-unique-id";
+		String name = "新規ユーザー";
+		String email = "new@example.com";
+
+		User savedUser = User.builder()
+				.uniqueUserId(uniqueUserId)
+				.nickname(name)
+				.displayEmail(email)
+				.build();
+
+		when(userRepository.findByUniqueUserIdAndIsDeletedFalse(uniqueUserId))
+				.thenReturn(Optional.empty());
+		when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+		User result = userService.findOrCreateUser(uniqueUserId, name, email);
+
+		assertThat(result).isEqualTo(savedUser);
+		verify(userRepository).findByUniqueUserIdAndIsDeletedFalse(uniqueUserId);
+		verify(userRepository).save(argThat(user ->
+				user.getUniqueUserId().equals(uniqueUserId) &&
+						user.getNickname().equals(name) &&
+						user.getDisplayEmail().equals(email)
+		));
+	}
+}


### PR DESCRIPTION
## 概要
ログイン機能の実装に伴い外部APIのGoogle認証を実装
メールアドレスと外部認証の実装を想定していましたが、実装方法が異なることに加え認証認可の理解が浅いためUXの観点から外部認証の実装のみに変更しました。
変更に伴い差分が多くなっています。

## 詳細
- AuthUserControllerの実装
- User domainの修正
  - emailをdisplayEmailに変更しフロントエンド側で表示または今後通知等に活用できるようにしました。
  - rolesの追加：アクセス権限を今後分けるにあたり設定。デフォルトは一般ユーザー
 - DTOの追加修正
   - フロントへ渡すUserDTOとログイン情報を渡すLoginDTOの作成。外部認証から受け取ったトークンIDよりペイロードを抽出するためのDTOの実装
- DTO追加によるMapperの追加
- Userrepositoryにメソッド追加
  - ID検索に加えユニークID（外部認証ID）での検索の実装：これによりフロント側での処理に使用するIDとログイン関連で使用するIDを分別しています。
- service（User・Auth）の実装
  - Userは内部操作におけるCRUD操作と外部認証の検索or登録を行います。
  - Authはログインに関する認証およびJWT生成を行います
- securityパッケージの実装
- JUnitテストの追加修正