### PR TITLE
Bucketの導入

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     // --- 外部サービス連携 (External Services) ---
     implementation 'com.google.genai:google-genai:1.12.0'
     implementation 'com.google.api-client:google-api-client:2.2.0'
+    implementation 'com.bucket4j:bucket4j_jdk17-core:8.14.0'
 }
 
 tasks.withType(JavaCompile).configureEach {


### PR DESCRIPTION
## 概要
外部 API である GeminiAI へのリクエストに対して、利用制限（レートリミット）を実装しました。

## 実装内容
- 依存関係追加: Bucket4j を導入し、AiService 内でレート制限を管理。
- 1分あたりのリクエスト制限: 不正利用や API フラッディング対策として、1 分間に最大 5 回までに制限。
- 1日あたりのリクエスト制限: 無料利用枠内で安全に運用するため、1 日 30 回までに制限。
- AI レスポンス制御: 現在、質問ごとの最大トークン数を 3,000 に設定。