### PR TITLE
デプロイに向けた環境設定の修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
-# ビルドステージ
-FROM gradle:jdk21-alpine as build
+# Gradle を使って JAR ファイルをビルド
+FROM gradle:jdk21-alpine AS builder
 WORKDIR /app
-COPY --chown=gradle:gradle . /app
-RUN gradle bootJar --no-daemon
+COPY . .
+RUN gradle bootJar
 
-# 実行ステージ
-FROM eclipse-temurin:21-jre-ubi10-minimal as final
-WORKDIR /app
-COPY --from=build /app/build/libs/*-SNAPSHOT.jar /app/app.jar
-RUN microdnf update && microdnf install -y nmap-ncat
-EXPOSE 8080
-CMD ["java", "-jar", "/app/app.jar"]
+# アプリケーションを実行
+FROM eclipse-temurin:21-jre-alpine
+COPY --from=builder /app/build/libs/revox-0.0.1-SNAPSHOT.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,0 +1,23 @@
+steps:
+  # JARファイルをビルドする
+  - name: 'gradle'
+    entrypoint: 'sh'
+    args: ['-c', 'gradle bootJar']
+
+  # ビルドしたJARファイルを含むDockerイメージをビルド
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'us-west1-docker.pkg.dev/revoxprod/revox-repository/backend:$COMMIT_SHA', '.']
+
+  # イメージをArtifact Registryにプッシュ
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'us-west1-docker.pkg.dev/revoxprod/revox-repository/backend:$COMMIT_SHA']
+
+  # VMにSSH接続し、デプロイスクリプトを実行
+  - name: 'gcr.io/cloud-builders/gcloud'
+    args:
+      - compute
+      - ssh
+      - portfolio-revox
+      - --zone=us-west1-a
+      - --command=./update-deploy.sh
+      - --project=revoxprod

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -21,9 +21,7 @@ services:
 
   # Spring Boot バックエンド
   backend:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: us-west1-docker.pkg.dev/revoxprod/revox-repository/backend:latest
     restart: always
     env_file:
       - ./secret/prod.env
@@ -34,7 +32,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    command: java -jar /app/app.jar
     networks:
       - revox-network
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,6 @@ spring:
     password: ${MYSQL_PASSWORD}
 
 gemini:
-  api-key: ${GEMINI_API_KEY}
   model: "gemini-2.5-flash"
   project-id: ${GOOGLE_CLOUD_PROJECT}
   location: ${GOOGLE_CLOUD_LOCATION}


### PR DESCRIPTION
## 概要
GCPでのVM（M2-Micro）でのコンテナ起動がメモリ不足のため不可となり対応を行いました

## 実施内容
Dockerファイル：コンテナ内でbuildさせるとメモリ不足となるためJARファイルを作成してコピーするように変更
docker-compose：build: ではなく image: を指定して、事前に作成したJARを含むイメージを読み込むに変更
cloudBuild：GCPサービスのartifact repositoryにJARファイルを保存しCloud BuildでArtifact Registryからイメージを取得してVMでコンテナを起動するようにしました