### PR TITLE
SupaBaseでのschema指定不足によるFlywayスクリプトの衝突errorの対策

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,7 @@ spring:
     enabled: true
     locations: classpath:db/migration
     baseline-on-migrate: true
+    schemas: dev
 
 ---
 # 本番環境プロファイル
@@ -42,3 +43,4 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+    schemas: prod


### PR DESCRIPTION
## 概要
Renderにてデプロイ実行するもエラー発生

## やったこと
SupaBaseでは１インスタンスにschema設定でdev,prodを作成
application.yml内でdevとprodを分けているがFlywayの設定でマイグレーションは共有していた
schemaの設定がないため実装しました