### PR TITLE
ダミーデータの規約違反に対してマイグレーションスクリプトの追加

### DIFF
--- a/src/main/resources/db/migration/V007__add_all_missing_required_columns.sql
+++ b/src/main/resources/db/migration/V007__add_all_missing_required_columns.sql
@@ -1,0 +1,28 @@
+-- V6（ダミーデータ）で不足していた必須項目の追加
+
+-- users テーブルの変更
+ALTER TABLE users ADD COLUMN is_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE users ADD COLUMN created_at TIMESTAMP WITH TIME ZONE NOT NULL;
+ALTER TABLE users ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE NOT NULL;
+
+UPDATE users SET created_at = NOW(), updated_at = NOW() WHERE created_at IS NULL;
+
+-- bikes テーブルの変更
+ALTER TABLE bikes ADD COLUMN is_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE bikes ADD COLUMN created_at TIMESTAMP WITH TIME ZONE NOT NULL;
+ALTER TABLE bikes ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE NOT NULL;
+
+UPDATE bikes SET created_at = NOW(), updated_at = NOW() WHERE created_at IS NULL;
+
+-- ai_questions テーブルの変更
+ALTER TABLE ai_questions ADD COLUMN created_at TIMESTAMP WITH TIME ZONE NOT NULL;
+ALTER TABLE ai_questions ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE NOT NULL;
+
+UPDATE ai_questions SET created_at = NOW(), updated_at = NOW() WHERE created_at IS NULL;
+
+-- maintenance_tasks テーブルの変更
+ALTER TABLE maintenance_tasks ADD COLUMN is_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE maintenance_tasks ADD COLUMN created_at TIMESTAMP WITH TIME ZONE NOT NULL;
+ALTER TABLE maintenance_tasks ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE NOT NULL;
+
+UPDATE maintenance_tasks SET created_at = NOW(), updated_at = NOW() WHERE created_at IS NULL;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,7 +4,7 @@ spring:
       on-profile: test
 
   datasource:
-    url: jdbc:postgresql://db.mygkdrjswiaaffbcpazq.supabase.co:5432/postgres?currentSchema=dev&sslmode=require
+    url: ${TEST_DB_URL}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
## 概要
ダミーデータのスクリプトに対し追加データの投入

## 理由
DBを無料枠運用するためにSupaBaseの１インスタンス内にschemaでdev prodを分けて運用しています
prodは本番用、devは開発とテストを共有して使用予定です

ローカルでテスト実行したところ開発中はH2にて実行していたため問題がなかったがDBを変更し単体テストから結合テストになった影響からバリデーションエラーが発生
マイグレーションスクリプトを確認し制約違反のデータを準備しました